### PR TITLE
add OBI terms, no parent checks

### DIFF
--- a/nec.owl
+++ b/nec.owl
@@ -749,6 +749,25 @@ obo:IAO_0000136 rdf:type owl:ObjectProperty ;
                 rdfs:label "is about" .
 
 
+###  http://purl.obolibrary.org/obo/OBI_0000304
+obo:OBI_0000304 rdf:type owl:ObjectProperty ;
+                rdfs:domain obo:BFO_0000040 ;
+                rdfs:range [ rdf:type owl:Class ;
+                             owl:unionOf ( obo:NCBITaxon_9606
+                                           obo:OBI_0000245
+                                         )
+                           ] ;
+                obo:IAO_0000111 "is_manufactured_by"@en ;
+                obo:IAO_0000112 "http://www.affymetrix.com/products/arrays/specific/hgu133.affx is_manufactered_by http://www.affymetrix.com/ (if we decide to use these URIs for the actual entities)"@en ;
+                obo:IAO_0000114 obo:IAO_0000123 ;
+                obo:IAO_0000115 "c is_manufactured_by o means that there was a process p in which c was built in which a person, or set of people or machines did the work(bore the \"Manufacturer Role\", and those people/and or machines were members or of directed by the organization to do this."@en ;
+                obo:IAO_0000117 "Alan Ruttenberg"@en ,
+                                "Liju Fan"@en ;
+                obo:IAO_0000118 "has_make"@en ,
+                                "has_manufacturer"@en ;
+                rdfs:label "is_manufactured_by"@en .
+
+
 ###  http://purl.obolibrary.org/obo/OBI_0000293
 obo:OBI_0000293 rdf:type owl:ObjectProperty ;
                 rdfs:subPropertyOf obo:RO_0000057 ;
@@ -2728,6 +2747,9 @@ obo:UO_0000003 rdf:type owl:Class ;
                obo:IAO_0000412 obo:uo.owl ;
                rdfs:label "time unit"^^xsd:string .
 
+
+
+
 ###  http://purl.org/nidash/nidm#Acquisition
 nidm:Acquisition rdf:type owl:Class ;
                rdfs:label "Acquisition" ;
@@ -2736,24 +2758,724 @@ nidm:Acquisition rdf:type owl:Class ;
                rdfs:subClassOf COB_0000082 .
 
 
-###  http://purl.org/nidash/nidm#ImmaterialAcquisitionObject
-nidm:AcquisitionObject rdf:type owl:Class ;
-               rdfs:label "Immaterial Acquisition Object"^^xsd:string ;
-               rdfs:subClassOf obo:BFO_0000041 ;
-               obo:IAO_0000115 "An immaterial acquisition object is an immaterial entity that is gathered from a subject during an acquisition activity."^^xsd:string ;
-	       rdfs:comment "This term encompasses immaterial objects such as time series and image files." ;
-               obo:IAO_0000114 obo:IAO_0000428 ;    
-               obo:IAO_0000117 <http://purl.org/nicholsn/card.ttl> .
+###  http://purl.obolibrary.org/obo/OBI_0000457
+obo:OBI_0000457 rdf:type owl:Class ;
+                owl:equivalentClass [ rdf:type owl:Restriction ;
+                                      owl:onProperty obo:OBI_0000417 ;
+                                      owl:someValuesFrom obo:OBI_0000458
+                                    ] ;
+                rdfs:subClassOf obo:OBI_0000094 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000293 ;
+                                  owl:someValuesFrom obo:BFO_0000040
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000299 ;
+                                  owl:someValuesFrom obo:OBI_0000047
+                                ] ;
+                obo:IAO_0000111 "manufacturing" ;
+                obo:IAO_0000114 obo:IAO_0000122 ;
+                obo:IAO_0000115 "Manufacturing is a process with the intent to produce a processed material which will have a function for future use. A person or organization (having manufacturer role) is a participant in this process"@en ;
+                obo:IAO_0000116 "Manufacturing implies reproducibility and responsibility AR" ,
+                                "This includes a single scientist making a processed material for personal use."@en ;
+                obo:IAO_0000117 "PERSON: Bjoern Peters" ,
+                                "PERSON: Frank Gibson" ,
+                                "PERSON: Jennifer Fostel" ,
+                                "PERSON: Melanie Courtot" ,
+                                "PERSON: Philippe Rocca-Serra" ;
+                obo:IAO_0000119 "GROUP: OBI PlanAndPlannedProcess Branch" ;
+                rdfs:label "manufacturing"@en .
 
 
-###  http://purl.org/nidash/nidm#MaterialAcquisitionObject
-nidm:AcquisitionObject rdf:type owl:Class ;
-               rdfs:label "Material Acquisition Object"^^xsd:string ;
-               rdfs:subClassOf obo:BFO_0000040 ;
-               obo:IAO_0000115 "An acquisition object is an material entity that is gathered from a subject during an acquisition activity."^^xsd:string ;
-	       rdfs:comment "This term encompasses material objects such as blood samples." ;
-               obo:IAO_0000114 obo:IAO_0000428 ;    
-               obo:IAO_0000117 <http://purl.org/nicholsn/card.ttl> .
+###  http://purl.obolibrary.org/obo/OBI_0000571
+obo:OBI_0000571 rdf:type owl:Class ;
+                rdfs:subClassOf obo:BFO_0000023 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:RO_0000052 ;
+                                  owl:someValuesFrom [ rdf:type owl:Class ;
+                                                       owl:unionOf ( obo:NCBITaxon_9606
+                                                                     obo:OBI_0000245
+                                                                   )
+                                                     ]
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000054 ;
+                                  owl:allValuesFrom obo:OBI_0000457
+                                ] ;
+                obo:IAO_0000111 "manufacturer role" ;
+                obo:IAO_0000112 "With respect to The Accuri C6 Flow Cytometer System, the organization Accuri bears the role manufacturer role.  With respect to a transformed line of tissue culture cells derived by a specific lab, the lab whose personnel isolated the cll line bears the role manufacturer role.  With respect to a specific antibody produced by an individual scientist, the scientist who purifies, characterizes and distributes the anitbody bears the role manufacturer role." ;
+                obo:IAO_0000114 obo:IAO_0000123 ;
+                obo:IAO_0000115 "Manufacturer role is a role which inheres in a person or organization and which is realized by a manufacturing process." ;
+                obo:IAO_0000117 "GROUP:  Role Branch" ;
+                obo:IAO_0000119 "OBI" ;
+                rdfs:label "manufacturer role" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0000671
+obo:OBI_0000671 rdf:type owl:Class ;
+                owl:equivalentClass [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
+                                                             owl:onProperty obo:OBI_0000312 ;
+                                                             owl:someValuesFrom obo:OBI_0600005
+                                                           ]
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty obo:RO_0000087 ;
+                                                             owl:someValuesFrom obo:OBI_0000740
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf obo:OBI_0000747 ,
+                                obo:OBI_0001479 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:RO_0001000 ;
+                                  owl:someValuesFrom obo:UBERON_0000465
+                                ] ;
+                obo:IAO_0000111 "sample from organism" ;
+                obo:IAO_0000114 obo:IAO_0000002 ;
+                obo:IAO_0000115 "a material obtained from an organism in order to be a representative of the whole" ;
+                obo:IAO_0000116 "5/29: This is a helper class for now" ,
+                                "we need to work on this: Is taking a urine sample a material separation process? If not, we will need to specify what 'taking a sample from organism' entails. We can argue that the objective to obtain a urine sample from a patient is enough to call it a material separation process, but it could dilute what material separation was supposed to be about." ;
+                rdfs:label "sample from organism" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0000740
+obo:OBI_0000740 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000112 ;
+                obo:IAO_0000111 "material sample role" ;
+                obo:IAO_0000112 "a role borne by a portion of blood taken to represent all the blood in an organism; the role borne by a population of humans with HIV enrolled in a study taken to represent patients with HIV in general." ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "A material sample role is a specimen role borne by a material entity that is the output of a material sampling process." ;
+                obo:IAO_0000116 "7/13/09: Note that this is a relational role: between the sample taken and the 'sampled' material of which the sample is thought to be representative off." ;
+                obo:IAO_0000233 <https://github.com/obi-ontology/obi/issues/1013> ;
+                rdfs:label "material sample role" .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0000744
+obo:OBI_0000744 rdf:type owl:Class ;
+                owl:equivalentClass [ owl:intersectionOf ( obo:OBI_0000659
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty obo:OBI_0000293 ;
+                                                             owl:someValuesFrom obo:BFO_0000040
+                                                           ]
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty obo:OBI_0000299 ;
+                                                             owl:someValuesFrom obo:OBI_0000747
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf obo:OBI_0000659 ;
+                obo:IAO_0000111 "material sampling process" ;
+                obo:IAO_0000114 obo:IAO_0000123 ;
+                obo:IAO_0000115 "A specimen gathering process with the objective to obtain a specimen that is representative of the input material entity" ;
+                obo:IAO_0000118 "sample collection" ,
+                                "sampling" ;
+                obo:IAO_0000233 "https://github.com/obi-ontology/obi/issues/1002" ;
+                rdfs:label "material sampling process" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0000747
+obo:OBI_0000747 rdf:type owl:Class ;
+                owl:equivalentClass [ owl:intersectionOf ( obo:BFO_0000040
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty obo:RO_0000087 ;
+                                                             owl:someValuesFrom obo:OBI_0000740
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf obo:OBI_0100051 ;
+                obo:IAO_0000111 "material sample" ;
+                obo:IAO_0000112 "blood drawn from patient to measure his systemic glucose level. A population of humans with HIV enrolled in a study taken to represent patients with HIV in general." ;
+                obo:IAO_0000114 obo:IAO_0000123 ;
+                obo:IAO_0000115 "A material entity that has the material sample role" ;
+                obo:IAO_0000117 "OBI: workshop" ;
+                obo:IAO_0000118 "sample population" ;
+                obo:IAO_0000233 <https://github.com/obi-ontology/obi/issues/1013> ;
+                obo:OBI_0001847 "sample" ;
+                rdfs:label "material sample" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0000835
+obo:OBI_0000835 rdf:type owl:Class ;
+                owl:equivalentClass [ owl:intersectionOf ( [ rdf:type owl:Class ;
+                                                             owl:unionOf ( obo:NCBITaxon_9606
+                                                                           obo:OBI_0000245
+                                                                         )
+                                                           ]
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty obo:RO_0000087 ;
+                                                             owl:someValuesFrom obo:OBI_0000571
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf obo:BFO_0000040 ;
+                obo:IAO_0000111 "manufacturer" ;
+                obo:IAO_0000114 obo:IAO_0000123 ;
+                obo:IAO_0000115 "A person or organization that has a manufacturer role" ;
+                rdfs:label "manufacturer" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0000841
+obo:OBI_0000841 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000011 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000050 ;
+                                  owl:someValuesFrom obo:OBI_0000810
+                                ] ;
+                obo:IAO_0000111 "subject agrees they understand informed consent document" ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A process in which a subject receives an informed consent document and agrees that they have understood it" ;
+                obo:IAO_0000116 "09/28/2009 Alan Ruttenberg. There's a need for a general process like this in IAO - document and person in, signed document (and associated obligations, rights, out" ;
+                obo:IAO_0000117 "Person:Alan Ruttenberg" ;
+                obo:IAO_0000232 "2009/09/28 Alan Ruttenberg. Fucoidan-use-case" ;
+                rdfs:label "subject agrees they understand informed consent document" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0000852
+obo:OBI_0000852 rdf:type owl:Class ;
+                rdfs:subClassOf obo:IAO_0000030 ;
+                obo:IAO_0000111 "record of missing knowledge" ;
+                obo:IAO_0000112 "A statement in a journal article indicating that the age of a patient at the onset of disease is not known. A statement indicating that the weight of a mouse was not measured." ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "An information content entity created to indicate that information about something is not available to the person recording it." ;
+                obo:IAO_0000116 "This class should probably end up in IAO. It could be further breaken down to indicate different kinds of lack of knowledge, e.g. inability to determine something vs. no attempt made to determine something vs. no informatino available if it was even attempted to determine something. The design pattern should be generalizable. 'unknown sex' is the first example, and needed immediately." ;
+                obo:IAO_0000117 "Bjoern Peters" ;
+                obo:IAO_0000119 "" ;
+                rdfs:label "record of missing knowledge" .
+
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0000873
+obo:OBI_0000873 rdf:type owl:Class ;
+                owl:equivalentClass [ rdf:type owl:Restriction ;
+                                      owl:onProperty obo:OBI_0000312 ;
+                                      owl:someValuesFrom [ owl:intersectionOf ( obo:OBI_0000659
+                                                                                [ rdf:type owl:Restriction ;
+                                                                                  owl:onProperty obo:OBI_0000293 ;
+                                                                                  owl:someValuesFrom [ owl:intersectionOf ( obo:OBI_0100026
+                                                                                                                            [ rdf:type owl:Restriction ;
+                                                                                                                              owl:onProperty obo:RO_0000086 ;
+                                                                                                                              owl:someValuesFrom obo:PATO_0001421
+                                                                                                                            ]
+                                                                                                                          ) ;
+                                                                                                       rdf:type owl:Class
+                                                                                                     ]
+                                                                                ]
+                                                                              ) ;
+                                                           rdf:type owl:Class
+                                                         ]
+                                    ] ;
+                rdfs:subClassOf obo:OBI_0001506 ;
+                owl:disjointWith obo:OBI_0000902 ;
+                obo:IAO_0000111 "pre-mortem specimen" ;
+                obo:IAO_0000112 "material obtained through a liver biopsy from a human patient" ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "a specimen that was taken from a live organism" ;
+                obo:IAO_0000117 "Bjoern Peters" ;
+                obo:IAO_0000119 "MO_705 premortem"@en ;
+                rdfs:label "pre-mortem specimen" .
+
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0000902
+obo:OBI_0000902 rdf:type owl:Class ;
+                owl:equivalentClass [ rdf:type owl:Restriction ;
+                                      owl:onProperty obo:OBI_0000312 ;
+                                      owl:someValuesFrom [ owl:intersectionOf ( obo:OBI_0000659
+                                                                                [ rdf:type owl:Restriction ;
+                                                                                  owl:onProperty obo:OBI_0000293 ;
+                                                                                  owl:someValuesFrom [ owl:intersectionOf ( obo:OBI_0100026
+                                                                                                                            [ rdf:type owl:Restriction ;
+                                                                                                                              owl:onProperty obo:RO_0000086 ;
+                                                                                                                              owl:someValuesFrom obo:PATO_0001422
+                                                                                                                            ]
+                                                                                                                          ) ;
+                                                                                                       rdf:type owl:Class
+                                                                                                     ]
+                                                                                ]
+                                                                              ) ;
+                                                           rdf:type owl:Class
+                                                         ]
+                                    ] ;
+                rdfs:subClassOf obo:OBI_0001506 ;
+                obo:IAO_0000111 "post mortem specimen" ;
+                obo:IAO_0000112 "the spleen taken from a dead mouse" ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "a specimen that was taken from a dead organism" ;
+                obo:IAO_0000117 "Bjoern Peters" ;
+                obo:IAO_0000119 "MO_416 postmortem"@en ;
+                rdfs:label "post mortem specimen" .
+
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0000915
+obo:OBI_0000915 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0302893 ,
+                                [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
+                                                         owl:onProperty obo:OBI_0000293 ;
+                                                         owl:someValuesFrom [ owl:intersectionOf ( obo:BFO_0000040
+                                                                                                   [ rdf:type owl:Restriction ;
+                                                                                                     owl:onProperty obo:RO_0000086 ;
+                                                                                                     owl:someValuesFrom obo:PATO_0001985
+                                                                                                   ]
+                                                                                                 ) ;
+                                                                              rdf:type owl:Class
+                                                                            ]
+                                                       ]
+                                                       [ rdf:type owl:Restriction ;
+                                                         owl:onProperty obo:OBI_0000299 ;
+                                                         owl:someValuesFrom [ owl:intersectionOf ( obo:BFO_0000040
+                                                                                                   [ rdf:type owl:Restriction ;
+                                                                                                     owl:onProperty obo:RO_0000086 ;
+                                                                                                     owl:someValuesFrom obo:PATO_0001985
+                                                                                                   ]
+                                                                                                 ) ;
+                                                                              rdf:type owl:Class
+                                                                            ]
+                                                       ]
+                                                     ) ;
+                                  rdf:type owl:Class
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000417 ;
+                                  owl:someValuesFrom obo:OBI_0000806
+                                ] ;
+                obo:IAO_0000111 "freezing storage" ;
+                obo:IAO_0000112 "a fozen pellet used for later assay" ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A storage process in temperature that maintenance the frozen status of the stored entities." ;
+                obo:IAO_0000116 """2010/3/3 Alan Ruttenberg: There is a question of whether we should have a separate objective to \"prepare for maintenance\"
+2014/2/3 OBI dev call: \"prepare for maintenance\" is a separate process. For example, 'freezing' and 'flash freezing' are defined and can be used to produce frozen material for storage.
+Updated both textual and logical definition. Both input and output material of freezing storage have quality frozen.""" ;
+                obo:IAO_0000117 "Person: Alan Ruttenberg, Mathias Brochhausen" ;
+                obo:IAO_0000119 "MO_481 frozen_storage"@en ,
+                                "OBI" ;
+                rdfs:label "freezing storage" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0000922
+obo:OBI_0000922 rdf:type owl:Class ;
+                owl:equivalentClass [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
+                                                             owl:onProperty obo:OBI_0000312 ;
+                                                             owl:someValuesFrom [ owl:intersectionOf ( obo:OBI_0000915
+                                                                                                       [ rdf:type owl:Restriction ;
+                                                                                                         owl:onProperty obo:OBI_0000293 ;
+                                                                                                         owl:someValuesFrom [ rdf:type owl:Restriction ;
+                                                                                                                              owl:onProperty obo:RO_0000087 ;
+                                                                                                                              owl:someValuesFrom obo:OBI_0000112
+                                                                                                                            ]
+                                                                                                       ]
+                                                                                                     ) ;
+                                                                                  rdf:type owl:Class
+                                                                                ]
+                                                           ]
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty obo:RO_0000087 ;
+                                                             owl:someValuesFrom obo:OBI_0000112
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf obo:OBI_0001472 ;
+                owl:disjointWith obo:OBI_0000950 ,
+                                 obo:OBI_0000965 ,
+                                 obo:OBI_0000971 ,
+                                 obo:OBI_0000981 ;
+                obo:IAO_0000111 "frozen specimen" ;
+                obo:IAO_0000112 "Frozen blood plasma" ;
+                obo:IAO_0000114 obo:IAO_0000123 ;
+                obo:IAO_0000115 "A specimen that has been frozen in order to store it." ;
+                obo:IAO_0000117 "Person:Alan Ruttenberg" ;
+                obo:IAO_0000119 "MO_610 frozen_sample" ;
+                rdfs:label "frozen specimen" .
+
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0000931
+obo:OBI_0000931 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000011 ,
+                                [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
+                                                         owl:onProperty obo:OBI_0000293 ;
+                                                         owl:someValuesFrom obo:OBI_0100051
+                                                       ]
+                                                       [ rdf:type owl:Restriction ;
+                                                         owl:onProperty obo:OBI_0000299 ;
+                                                         owl:someValuesFrom obo:OBI_0100051
+                                                       ]
+                                                     ) ;
+                                  rdf:type owl:Class
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000050 ;
+                                  owl:someValuesFrom [ owl:intersectionOf ( obo:OBI_0000471
+                                                                            [ rdf:type owl:Restriction ;
+                                                                              owl:onProperty obo:BFO_0000055 ;
+                                                                              owl:someValuesFrom [ rdf:type owl:Restriction ;
+                                                                                                   owl:onProperty obo:RO_0000059 ;
+                                                                                                   owl:someValuesFrom obo:OBI_0000115
+                                                                                                 ]
+                                                                            ]
+                                                                          ) ;
+                                                       rdf:type owl:Class
+                                                     ]
+                                ] ;
+                obo:IAO_0000111 "study intervention" ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "the part of the execution of an intervention design study which is varied between two or more subjects in the study" ;
+                obo:IAO_0000117 "PERSON: Bjoern Peters" ;
+                obo:IAO_0000119 "GROUP: OBI" ;
+                rdfs:label "study intervention"
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0000933
+obo:OBI_0000933 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000398 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:RO_0000085 ;
+                                  owl:someValuesFrom obo:OBI_0000397
+                                ] ;
+                obo:IAO_0000111 "positron emission tomography scanner" ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A device that produces a three-dimensional image or picture of functional processes in the body. It detects pairs of gamma rays emitted indirectly by a positron-emitting radionuclide (tracer), which is introduced into the body on a biologically active molecule." ;
+                obo:IAO_0000117 "PERSON:Bjoern Peters" ;
+                obo:IAO_0000118 "PET scanner?" ;
+                obo:IAO_0000119 "http://en.wikipedia.org/wiki/Positron_emission_tomography" ;
+                rdfs:label "positron emission tomography scanner" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0000939
+obo:OBI_0000939 rdf:type owl:Class ;
+                owl:equivalentClass [ rdf:type owl:Restriction ;
+                                      owl:onProperty obo:OBI_0000417 ;
+                                      owl:someValuesFrom obo:OBI_0000962
+                                    ] ;
+                rdfs:subClassOf obo:OBI_0000011 ;
+                obo:IAO_0000111 "training process" ;
+                obo:IAO_0000112 "e.g. a training course run by a vendor on their instrument, a training service on a assay by a core facility" ;
+                obo:IAO_0000114 obo:IAO_0000123 ;
+                obo:IAO_0000115 "a process that achieves a training objective" ;
+                rdfs:label "training process" .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0000944
+obo:OBI_0000944 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000070 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000299 ;
+                                  owl:someValuesFrom obo:IAO_0000109
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000299 ;
+                                  owl:someValuesFrom [ rdf:type owl:Restriction ;
+                                                       owl:onProperty obo:IAO_0000136 ;
+                                                       owl:someValuesFrom obo:PATO_0002201
+                                                     ]
+                                ] ;
+                obo:IAO_0000111 "handedness assay" ;
+                obo:IAO_0000112 "The Edinburgh handedness assay is a specific method of determing handedness" ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "An assay that measures the unequal distribution of fine motor skill between the left and right hands typically in human subjects by means of some questionnaire and scoring procedure." ;
+                obo:IAO_0000117 "Helen Parkinson" ;
+                obo:IAO_0000118 "handedness test" ;
+                obo:IAO_0000119 "url:http://en.wikipedia.org/wiki/Handedness" ;
+                rdfs:label "handedness assay" .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0000953
+obo:OBI_0000953 rdf:type owl:Class ;
+                owl:equivalentClass [ owl:intersectionOf ( obo:OBI_0000047
+                                                           obo:OBI_0100051
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf obo:OBI_0000047 ,
+                                obo:OBI_0100051 ;
+                obo:IAO_0000111 "processed specimen" ;
+                obo:IAO_0000112 """A tissue sample that has been sliced and stained for a histology study.
+A blood specimen that has been centrifuged to obtain the white blood cells.""" ;
+                obo:IAO_0000114 obo:IAO_0000122 ;
+                obo:IAO_0000115 "A specimen that has been intentionally physically modified." ;
+                obo:IAO_0000117 "Bjoern Peters" ;
+                obo:IAO_0000119 "Bjoern Peters" ;
+                rdfs:comment "A tissue sample that has been sliced and stained for a histology study." ;
+                rdfs:label "processed specimen" .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0000957
+obo:OBI_0000957 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000944 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000299 ;
+                                  owl:someValuesFrom obo:OBI_0000938
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000299 ;
+                                  owl:someValuesFrom [ rdf:type owl:Restriction ;
+                                                       owl:onProperty obo:IAO_0000136 ;
+                                                       owl:someValuesFrom obo:PATO_0002201
+                                                     ]
+                                ] ;
+                obo:IAO_0000111 "self reported handedness assessment" ;
+                obo:IAO_0000114 obo:IAO_0000123 ;
+                obo:IAO_0000115 "An assay where a person makes a statement that indicates what handedness he has from a choice of different categories." ;
+                rdfs:label "self reported handedness assessment" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0000963
+obo:OBI_0000963 rdf:type owl:Class ;
+                rdfs:subClassOf obo:IAO_0000009 ;
+                obo:IAO_0000111 "categorical label" ;
+                obo:IAO_0000112 "The labels 'positive' vs. 'negative', or 'left handed', 'right handed', 'ambidexterous', or 'strongly binding', 'weakly binding' , 'not binding', or '+++', '++', '+', '-' etc. form scales of categorical labels." ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A label that is part of a categorical datum and that indicates the value of the data item on the categorical scale." ;
+                obo:IAO_0000117 "Bjoern Peters" ;
+                obo:IAO_0000119 "Bjoern Peters" ;
+                rdfs:label "categorical label" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0000967
+obo:OBI_0000967 rdf:type owl:Class ;
+                owl:equivalentClass [ owl:intersectionOf ( obo:OBI_0000968
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty obo:RO_0000085 ;
+                                                             owl:someValuesFrom obo:OBI_0000370
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf obo:OBI_0000968 ;
+                obo:IAO_0000111 "container" ;
+                obo:IAO_0000114 obo:IAO_0000123 ;
+                obo:IAO_0000115 "A device that can be used to restrict the location of material entities over time" ;
+                obo:IAO_0000116 "03/21/2010: Added to allow classification of children (similar to what we want to do for 'measurement device'. Lookint at what classifies here, we may want to reconsider a contain function assigned to a part of an entity is necessarily also a function of the whole (e.g. is a centrifuge a container because it has test tubes as parts?)" ;
+                obo:IAO_0000117 "PERSON: Bjoern Peters" ;
+                rdfs:label "container" .
+
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0000968
+obo:OBI_0000968 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000047 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000312 ;
+                                  owl:someValuesFrom obo:OBI_0000094
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:RO_0000085 ;
+                                  owl:someValuesFrom obo:BFO_0000034
+                                ] ;
+                owl:disjointWith [ owl:intersectionOf ( obo:BFO_0000040
+                                                        [ rdf:type owl:Restriction ;
+                                                          owl:onProperty obo:RO_0000087 ;
+                                                          owl:someValuesFrom obo:OBI_0000086
+                                                        ]
+                                                      ) ;
+                                   rdf:type owl:Class
+                                 ] ;
+                obo:IAO_0000111 "device" ;
+                obo:IAO_0000112 "A voltmeter is a measurement device which is intended to perform some measure function." ,
+                                "An autoclave is a device that sterlizes instruments or contaminated waste by applying high temperature and pressure." ;
+                obo:IAO_0000114 obo:IAO_0000122 ;
+                obo:IAO_0000115 "A material entity that is designed to perform a function in a scientific investigation, but is not a reagent." ;
+                obo:IAO_0000116 """2012-12-17 JAO: In common lab usage, there is a distinction made between devices and reagents that is difficult to model. Therefore we have chosen to specifically exclude reagents from the definition of \"device\", and are enumerating the types of roles that a reagent can perform.
+
+2013-6-5 MHB: The following clarifications are outcomes of the May 2013 Philly Workshop. Reagents are distinguished from devices that also participate in scientific techniques by the fact that reagents are chemical or biological in nature and necessarily participate in some chemical interaction or reaction during the realization of their experimental role. By contrast, devices do not participate in such chemical reactions/interactions.  Note that there are cases where devices use reagent components during their operation, where the reagent-device distinction is less clear.  For example:
+
+(1) An HPLC machine is considered a device, but has a column that holds a stationary phase resin as an operational component.  This resin qualifies as a device if it participates purely in size exclusion, but bears a reagent role that is realized in the running of a column if it interacts electrostatically or chemically with the evaluant. The container the resin is in (“the column”) considered alone is a device. So the entire column as well as the entire HPLC machine are devices that have a reagent as an operating part.
+
+(2) A pH meter is a device, but its electrode component bears a reagent role in virtue of its interacting directly with the evaluant in execution of an assay.
+
+(3) A gel running  box  is a device that has a metallic lead as a component that participates in a chemical reaction with the running buffer when a charge is passed through it.  This metallic lead is considered to have a reagent role as a component of this device realized in the running of a gel.
+
+In the examples above, a reagent is an operational component of a device, but the device itself does not realize a reagent role (as bearing a reagent role is not transitive across the part_of relation).  In this way, the asserted disjointness between a reagent and device holds, as both roles are never realized in the same bearer during execution of an assay.""" ;
+                obo:IAO_0000117 "PERSON: Helen Parkinson" ;
+                obo:IAO_0000118 "instrument" ;
+                obo:IAO_0000119 "OBI development call 2012-12-17." ;
+                rdfs:label "device" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0000970
+obo:OBI_0000970 rdf:type owl:Class ;
+                rdfs:subClassOf obo:IAO_0000032 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000312 ;
+                                  owl:someValuesFrom obo:OBI_0200000
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:IAO_0000004 ;
+                                  owl:minCardinality "1"^^xsd:nonNegativeInteger
+                                ] ;
+                obo:IAO_0000111 "scalar score from composite inputs" ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A measurement datum which is the result of combining multiple datum. For example, a mean or summary score."@en ;
+                obo:IAO_0000116 "JT:  We included this because we wanted to talk about an output from a questionnaire that summarized the answers to the questionnaire, but which was not actually the answer to any single question."@en ;
+                obo:IAO_0000117 "Person: Jessica Turner"@en ;
+                obo:IAO_0000118 "questionaire score" ;
+                obo:IAO_0000119 "Person: Jessica Turner"@en ;
+                obo:IAO_0000232 "JZ: can we defined it logically as the output of some data transformation, like aggragate data transformation?"@en ;
+                rdfs:label "scalar score from composite inputs" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0000971
+obo:OBI_0000971 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0001472 ;
+                owl:disjointWith obo:OBI_0000981 ;
+                obo:IAO_0000111 "fresh specimen" ;
+                obo:IAO_0000112 "a liver freshly removed from a rat" ;
+                obo:IAO_0000114 obo:IAO_0000123 ;
+                obo:IAO_0000115 "a specimen that is output of a specimen creation process used for an investigation without storage." ;
+                obo:IAO_0000117 "PERSON: Chris Stoeckert" ,
+                                "PERSON: Jie Zheng" ;
+                obo:IAO_0000119 "MO_730 fresh_sample" ;
+                rdfs:label "fresh specimen" .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0000976
+obo:OBI_0000976 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000938 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:IAO_0000221 ;
+                                  owl:someValuesFrom obo:PATO_0002201
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000999 ;
+                                  owl:someValuesFrom [ rdf:type owl:Class ;
+                                                       owl:oneOf ( obo:OBI_0000958
+                                                                   obo:OBI_0000979
+                                                                   obo:OBI_0000998
+                                                                 )
+                                                     ]
+                                ] ;
+                obo:IAO_0000111 "handedness categorical measurement datum" ;
+                obo:IAO_0000114 obo:IAO_0000123 ;
+                obo:IAO_0000115 "A datum used to record the answer to a self assessment of whether a person uses their left hand, right hand primarily or each hand equally" ;
+                obo:IAO_0000117 "PERSON:Alan Ruttenberg" ,
+                                "PERSON:Jessica Turner" ;
+                rdfs:label "handedness categorical measurement datum" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0000982
+obo:OBI_0000982 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000398 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:RO_0000085 ;
+                                  owl:someValuesFrom obo:OBI_0000397
+                                ] ;
+                obo:IAO_0000111 "computed tomography scanner" ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "An image acquisition device that generates a three-dimensional image of the inside of an object from a large series of two-dimensional X-ray images taken around a single axis of rotation." ;
+                obo:IAO_0000117 "PERSON:Bjoern Peters" ;
+                obo:IAO_0000118 "CT scanner" ,
+                                "X-ray computed tomography scanner" ;
+                obo:IAO_0000119 "http://en.wikipedia.org/wiki/X-ray_computed_tomography" ;
+                rdfs:label "computed tomography scanner" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0000984
+obo:OBI_0000984 rdf:type owl:Class ;
+                rdfs:subClassOf obo:IAO_0000109 ;
+                obo:IAO_0000111 "dose" ;
+                obo:IAO_0000112 "An organism has been injected 1ml of vaccine" ;
+                obo:IAO_0000114 obo:IAO_0000123 ;
+                obo:IAO_0000115 "A measurement datum that measures the quantity of something that may be administered to an organism or that an organism may be exposed to. Quantities of nutrients, drugs, vaccines and toxins are referred to as doses." ;
+                rdfs:label "dose" .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0000990
+obo:OBI_0000990 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0400169 ;
+                obo:IAO_0000111 "electron microscope" ;
+                obo:IAO_0000114 obo:IAO_0000123 ;
+                obo:IAO_0000115 "A microscope that produces an image of an object by targeting it with an electron beam" ;
+                rdfs:label "electron microscope" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0000991
+obo:OBI_0000991 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000970 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:IAO_0000221 ;
+                                  owl:someValuesFrom obo:PATO_0002201
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:IAO_0000004 ;
+                                  owl:minCardinality "1"^^xsd:nonNegativeInteger
+                                ] ;
+                obo:IAO_0000111 "Edinburgh score" ;
+                obo:IAO_0000114 obo:IAO_0000123 ;
+                obo:IAO_0000115 "A score that measures the dominance of a person's right or left hand in everyday activities." ;
+                obo:IAO_0000117 "Person: Alan Ruttenberg" ,
+                                "Person:Jessica Turner" ;
+                obo:IAO_0000119 "PMID:5146491#Oldfield, R.C. (1971). The assessment and analysis of handedness: The Edinburgh inventory. Neuropsychologia, 9, 97-113" ,
+                                "WEB:http://www.cse.yorku.ca/course_archive/2006-07/W/4441/EdinburghInventory.html" ;
+                rdfs:label "Edinburgh score" .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0000994
+obo:OBI_0000994 rdf:type owl:Class ;
+                owl:equivalentClass [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
+                                                             owl:onProperty obo:BFO_0000055 ;
+                                                             owl:someValuesFrom obo:OBI_0000319
+                                                           ]
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty obo:BFO_0000055 ;
+                                                             owl:someValuesFrom [ owl:intersectionOf ( obo:BFO_0000034
+                                                                                                       [ rdf:type owl:Restriction ;
+                                                                                                         owl:onProperty obo:RO_0000052 ;
+                                                                                                         owl:someValuesFrom obo:OBI_0000422
+                                                                                                       ]
+                                                                                                     ) ;
+                                                                                  rdf:type owl:Class
+                                                                                ]
+                                                           ]
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty obo:BFO_0000055 ;
+                                                             owl:someValuesFrom [ owl:intersectionOf ( obo:OBI_0000444
+                                                                                                       [ rdf:type owl:Restriction ;
+                                                                                                         owl:onProperty obo:RO_0000081 ;
+                                                                                                         owl:someValuesFrom obo:UBERON_0001638
+                                                                                                       ]
+                                                                                                     ) ;
+                                                                                  rdf:type owl:Class
+                                                                                ]
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf obo:OBI_0000426 ,
+                                obo:OBI_0600007 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000417 ;
+                                  owl:someValuesFrom obo:OBI_0000434
+                                ] ;
+                obo:IAO_0000111 "intravenous injection" ;
+                obo:IAO_0000114 obo:IAO_0000123 ;
+                obo:IAO_0000115 "is the injection of a material entity (bearing the administered substance role) into the vein (bearing the target role) of an organism using a syringe" ;
+                obo:IAO_0000117 "PERSON: Melanie Courtot" ;
+                rdfs:label "intravenous injection" .
 
 
 ###  http://purl.org/nidash/nidm#AcquisitionDeviceOperator
@@ -2763,6 +3485,6489 @@ nidm:AcquisitionDeviceOperator rdf:type owl:Class ;
                obo:IAO_0000114 obo:IAO_0000428 ;
                rdfs:comment "The use of who/that indicates that the agent performing this role can either be a person or another device." ;                                
                rdfs:subClassOf obo:SEPIO_0000048 .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0000995
+obo:OBI_0000995 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000274 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000055 ;
+                                  owl:someValuesFrom [ owl:intersectionOf ( obo:OBI_0000444
+                                                                            [ rdf:type owl:Restriction ;
+                                                                              owl:onProperty obo:RO_0000081 ;
+                                                                              owl:someValuesFrom obo:OBI_0100051
+                                                                            ]
+                                                                          ) ;
+                                                       rdf:type owl:Class
+                                                     ]
+                                ] ;
+                obo:IAO_0000111 "administration of material to specimen" ;
+                obo:IAO_0000112 "Staining cells in a tissue slice with a dye." ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "The directed combination of a material entity with a specimen." ;
+                obo:IAO_0000117 "Bjoern Peters" ;
+                obo:IAO_0000119 "Bjoern Peters" ;
+                rdfs:label "administration of material to specimen" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0001000
+obo:OBI_0001000 rdf:type owl:Class ;
+                rdfs:subClassOf obo:IAO_0000310 ;
+                obo:IAO_0000111 "questionnaire" ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A document with a set of printed or written questions with a choice of answers, devised for the purposes of a survey or statistical study."@en ;
+                obo:IAO_0000116 """JT: It plays a role in collecting data that could be fleshed out more; but I'm thinking it is, in itself, an edited document. 
+JZ: based on textual definition of edited document, it can be defined as N&S. I prefer to leave questionnaire as a document now. We can add more restrictions in the future and use that to determine it is an edited document or not."""@en ,
+                                "Need to clarify if this is a document or a directive information entity (or what their connection is))" ;
+                obo:IAO_0000117 "PERSON: Jessica Turner"@en ;
+                obo:IAO_0000119 "Merriam-Webster"@en ;
+                rdfs:label "questionnaire" .
+
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0001001
+obo:OBI_0001001 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000944 ,
+                                [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
+                                                         owl:onProperty obo:BFO_0000055 ;
+                                                         owl:someValuesFrom [ owl:intersectionOf ( obo:OBI_0000067
+                                                                                                   [ rdf:type owl:Restriction ;
+                                                                                                     owl:onProperty obo:RO_0000081 ;
+                                                                                                     owl:someValuesFrom obo:NCBITaxon_9606
+                                                                                                   ]
+                                                                                                 ) ;
+                                                                              rdf:type owl:Class
+                                                                            ]
+                                                       ]
+                                                       [ rdf:type owl:Restriction ;
+                                                         owl:onProperty obo:OBI_0000293 ;
+                                                         owl:someValuesFrom [ owl:intersectionOf ( obo:NCBITaxon_9606
+                                                                                                   [ rdf:type owl:Restriction ;
+                                                                                                     owl:onProperty obo:RO_0000087 ;
+                                                                                                     owl:someValuesFrom obo:OBI_0000067
+                                                                                                   ]
+                                                                                                 ) ;
+                                                                              rdf:type owl:Class
+                                                                            ]
+                                                       ]
+                                                     ) ;
+                                  rdf:type owl:Class
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000299 ;
+                                  owl:someValuesFrom obo:OBI_0000991
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000293 ;
+                                  owl:hasValue obo:OBI_0001004
+                                ] ;
+                obo:IAO_0000111 "Edinburgh handedness assay" ;
+                obo:IAO_0000112 "Verdino (1998) Perceptual and Motor Skills. 86 (2): 476_8. (PMID: 9638746) uses this measure in an experimental study: \"Individuals of extreme handedness based on the Edinburgh Handedness Inventory (laterality Quotients of +90 to +100 and -100 and +54; 50 each)\"" ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "An assay that uses a set of questions (the Edinburgh Handedness inventory) to generate a score that can be used to assess the dominance of a person's right or left hand in everyday activities. The inventory can be used by an observer assessing the person, or by a person self-reporting hand use. The latter method tends to be less reliable due to a person over-attributing tasks to the dominant hand." ;
+                obo:IAO_0000117 "Alan Ruttenberg" ,
+                                "Gully Burns (orcid:0000-0003-1493-865X)" ,
+                                "Jessica Turner" ;
+                obo:IAO_0000119 "PMID:5146491" ,
+                                "url:http://en.wikipedia.org/wiki/Edinburgh_Handedness_Inventory" ;
+                rdfs:label "Edinburgh handedness assay" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0001007
+obo:OBI_0001007 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000011 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000293 ;
+                                  owl:someValuesFrom obo:BFO_0000040
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000299 ;
+                                  owl:someValuesFrom obo:IAO_0000101
+                                ] ;
+                obo:IAO_0000111 "image acquisition" ;
+                obo:IAO_0000112 "Taking a polaroid picture of a patients skin lesion; Using a digital camera to take a picture of a gel" ;
+                obo:IAO_0000114 obo:IAO_0000123 ;
+                obo:IAO_0000115 "A planned process that captures an image of an object." ;
+                obo:IAO_0000117 "PERSON: Jie Zheng" ;
+                obo:IAO_0000118 "image acquisition" ;
+                rdfs:label "image creation" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0001028
+obo:OBI_0001028 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0200000 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000293 ;
+                                  owl:someValuesFrom obo:IAO_0000101
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000299 ;
+                                  owl:someValuesFrom obo:IAO_0000027
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000417 ;
+                                  owl:someValuesFrom obo:OBI_0200005
+                                ] ;
+                obo:IAO_0000111 "feature extraction" ;
+                obo:IAO_0000114 obo:IAO_0000123 ;
+                obo:IAO_0000115 "A planed process with objective of obtaining quantified values from an image." ;
+                obo:IAO_0000117 "PERSON: Jie Zheng" ;
+                obo:IAO_0000119 "MO_928: feature_extraction" ;
+                rdfs:comment "" ;
+                rdfs:label "feature extraction" .
+
+
+### NOT A FAN OF THIS TERM
+###  http://purl.obolibrary.org/obo/OBI_0001031
+obo:OBI_0001031 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0001007 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000293 ;
+                                  owl:someValuesFrom obo:OBI_0400147
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000299 ;
+                                  owl:someValuesFrom obo:IAO_0000101
+                                ] ;
+                obo:IAO_0000111 "array image acquisition" ;
+                obo:IAO_0000114 obo:IAO_0000123 ;
+                obo:IAO_0000115 "An image creation process that generate an image from the array." ;
+                obo:IAO_0000117 "PERSON: Jie Zheng" ;
+                obo:IAO_0000118 "array image acquisition" ;
+                obo:IAO_0000119 "MO_929: image_acquisition" ;
+                rdfs:label "array image creation" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0001068
+obo:OBI_0001068 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000398 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:RO_0000085 ;
+                                  owl:someValuesFrom obo:OBI_0000397
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:RO_0000085 ;
+                                  owl:someValuesFrom obo:OBI_0000453
+                                ] ;
+                obo:IAO_0000111 "SPECT scanner" ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A nuclear medicine tomographic imaging device that uses gamma rays to provide 3D information, typically presented as cross-sectional slices through the specimen but with the ability to be freely reformatted or manipulated as required." ;
+                obo:IAO_0000117 "PERSON: Erik Segerdell" ;
+                obo:IAO_0000119 "http://en.wikipedia.org/wiki/Single_photon_emission_computed_tomography" ;
+                rdfs:label "SPECT scanner" .
+		
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0001080
+obo:OBI_0001080 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000832 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:RO_0000085 ;
+                                  owl:someValuesFrom obo:OBI_0000453
+                                ] ;
+                obo:IAO_0000111 "patch clamp device" ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A device used in electrophysiology that allows the study of single or multiple ion channels in cells." ;
+                obo:IAO_0000117 "PERSON: Erik Segerdell" ;
+                obo:IAO_0000119 "http://en.wikipedia.org/wiki/Patch_clamp" ;
+                rdfs:label "patch clamp device" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0001098
+obo:OBI_0001098 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000398 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:RO_0000085 ;
+                                  owl:someValuesFrom obo:OBI_0000397
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:RO_0000085 ;
+                                  owl:someValuesFrom obo:OBI_0000453
+                                ] ;
+                obo:IAO_0000111 "ultrasound machine" ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A device that is used to visualize subcutaneous body structures including tendons, muscles, joints, vessels and internal organs." ;
+                obo:IAO_0000117 "PERSON: Erik Segerdell" ;
+                obo:IAO_0000119 "http://en.wikipedia.org/wiki/Sonography" ;
+                rdfs:label "ultrasound machine" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0001167
+obo:OBI_0001167 rdf:type owl:Class ;
+                rdfs:subClassOf obo:IAO_0000416 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:IAO_0000221 ;
+                                  owl:someValuesFrom obo:PATO_0000011
+                                ] ;
+                obo:IAO_0000111 "age measurement datum"@en ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A time measurement datum that is the result of measurement of age of an organism" ;
+                obo:IAO_0000116 """note that we are currently defining subtypes of age measurement datum that specify when the age is relative to, e.g. planting, as we don't have adequate temporal predicates yet.
+life of bearer doesn't imply organism
+this assay measures time not developmental stage. we recognize that development can take different time periods under different conditions such as media / temperature
+age as a quality is dubious; we plan to revisit
+stages in development are currently handled with controlled vocabulary, such as 2-somite stage.""" ;
+                obo:IAO_0000117 "PERSON: Alan Ruttenberg, Chris Stoeckert, Jie Zheng" ;
+                obo:IAO_0000119 "MO_178 Age" ;
+                obo:IAO_0000232 """In MageTab file, we use
+initialTimePoint (a process) + age (a number expected) + TimeUnit (definied in UO, such as year, hour, day, etc.)
+Now we use the term label indicating the start time point of measuring the age, (number + TimeUnit) are expected instances of the class""" ,
+                                """discussed on Nov 15, dev call
+All subtype will be defined by textual definition now.""" ;
+                rdfs:label "age measurement datum"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0001169
+obo:OBI_0001169 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0001167 ;
+                obo:IAO_0000111 "age since birth measurement datum"@en ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "An age measurement datum that is the result of the measurement of the age of an organism since birth, the process of emergence and separation of offspring from the mother." ;
+                obo:IAO_0000117 "PERSON:Chris Stoeckert, Jie Zheng" ;
+                obo:IAO_0000119 "MO_710 birth" ;
+                rdfs:label "age since birth measurement datum"@en .
+
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0001479
+obo:OBI_0001479 rdf:type owl:Class ;
+                owl:equivalentClass [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
+                                                             owl:onProperty obo:RO_0000087 ;
+                                                             owl:someValuesFrom obo:OBI_0000112
+                                                           ]
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty obo:RO_0001000 ;
+                                                             owl:someValuesFrom [ rdf:type owl:Class ;
+                                                                                  owl:unionOf ( obo:UBERON_0000465
+                                                                                                obo:UBERON_0000477
+                                                                                              )
+                                                                                ]
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf obo:OBI_0100051 ;
+                obo:IAO_0000111 "specimen from organism"@en ;
+                obo:IAO_0000114 obo:IAO_0000122 ;
+                obo:IAO_0000115 "A specimen that derives from an anatomical part or substance arising from an organism. Examples of tissue specimen include tissue, organ, physiological system, blood, or body location (arm)." ;
+                obo:IAO_0000117 "PERSON: Chris Stoeckert, Jie Zheng" ;
+                obo:IAO_0000118 "tissue specimen"@en ;
+                obo:IAO_0000119 "MO_954 organism_part" ;
+                rdfs:label "specimen from organism"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0001508
+obo:OBI_0001508 rdf:type owl:Class ;
+                rdfs:subClassOf obo:IAO_0000416 ;
+                obo:IAO_0000111 "sampling time measurement datum"@en ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A time measurement datum when an observation is made or a sample is taken from a material as measured from some reference point." ;
+                obo:IAO_0000117 "Person: Chris Stoeckert"@en ;
+                obo:IAO_0000118 "time point"@en ;
+                obo:IAO_0000119 "MO_738 timepoint"@en ;
+                rdfs:label "sampling time measurement datum"@en .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0001530
+obo:OBI_0001530 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0001173 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000293 ;
+                                  owl:someValuesFrom obo:IAO_0000030
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000299 ;
+                                  owl:someValuesFrom obo:IAO_0000030
+                                ] ;
+                obo:IAO_0000111 "data service" ;
+                obo:IAO_0000112 "Data analysis service such statistical abalysis or storage service such data  backup." ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "A service that has some information content entity as input and output." ;
+                obo:IAO_0000117 "PERSON: Carlo Torniai" ,
+                                "PERSON: Matthew Brush" ;
+                obo:IAO_0000119 "PERSON: Carlo Torniai" ;
+                rdfs:comment "Information content entity was used as specified input and output since it was more appropriate then data item or dataset." ;
+                rdfs:label "data service" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0001533
+obo:OBI_0001533 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0001530 ;
+                obo:IAO_0000111 "data storage service" ;
+                obo:IAO_0000112 "A service offering data backup" ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "A storage service in which a service consumer provides data as input which a service provider stores and returns as output in its original form." ;
+                obo:IAO_0000117 "PERSON: Carlo Torniai" ,
+                                "PERSON: Matthew Brush" ;
+                obo:IAO_0000119 "PERSON: Matthew Brush" ;
+                rdfs:label "data storage service" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0001547
+obo:OBI_0001547 rdf:type owl:Class ;
+                owl:equivalentClass [ owl:intersectionOf ( obo:OBI_0001528
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty obo:OBI_0000107 ;
+                                                             owl:someValuesFrom obo:OBI_0000070
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf obo:OBI_0001528 ;
+                obo:IAO_0000111 "material analysis service" ;
+                obo:IAO_0000112 "Services performing DNA sequencing or Cell Analysis" ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "A service in which a service consumer provides some input material and a service provider performs some analysis of this material to generate data that is returned to the service consumer." ;
+                obo:IAO_0000117 "PERSON: Carlo Torniai" ,
+                                "PERSON: Matthew Brush" ;
+                obo:IAO_0000119 "PERSON: Matthew Brush" ;
+                rdfs:label "material analysis service" .
+
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0001557
+obo:OBI_0001557 rdf:type owl:Class ;
+                owl:equivalentClass [ owl:intersectionOf ( obo:OBI_0001528
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty obo:OBI_0000107 ;
+                                                             owl:someValuesFrom obo:OBI_0302893
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf obo:OBI_0001515 ;
+                obo:IAO_0000111 "material storage service" ;
+                obo:IAO_0000112 "A service that offers liquid nitrogen stroage." ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "A storage service in which a service consumer provides some material as input which a service provider stores and returns as output." ;
+                obo:IAO_0000117 "PERSON: Carlo Torniai" ,
+                                "PERSON: Matthew Brush" ;
+                obo:IAO_0000119 "PERSON: Matthew Brush" ;
+                rdfs:label "material storage service" .
+
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0001563
+obo:OBI_0001563 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0001528 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000107 ;
+                                  owl:someValuesFrom obo:OBI_0000094
+                                ] ;
+                obo:IAO_0000111 "material processing service" ;
+                obo:IAO_0000112 "A service for cell line creation. A service providing cel line immortalization." ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "A service in which a service provider makes physical changes to a specified input material entity with the objective of producing a new material entity form input materials, or modifying the input material entity, and returning this as output to the service consumer." ;
+                obo:IAO_0000117 "PERSON: Carlo Torniai" ,
+                                "PERSON: Matthew Brush" ;
+                obo:IAO_0000119 "PERSON: Carlo Torniai" ;
+                rdfs:label "material processing service" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0001573
+obo:OBI_0001573 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000973 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:IAO_0000136 ;
+                                  owl:someValuesFrom obo:OBI_0000811
+                                ] ;
+                obo:IAO_0000111 "DNA sequence data" ;
+                obo:IAO_0000112 "The part of a FASTA file that contains the letters ACTGGGAA" ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A sequence data item that is about the primary structure of DNA" ;
+                obo:IAO_0000117 "OBI call; Bjoern Peters" ;
+                obo:IAO_0000119 "OBI call; Melanie Courtout" ;
+                obo:IAO_0000232 "8/29/11 call: This is added after a request from Melanie and Yu. They should review it further. This should be a child of 'sequence data', and as of the current definition will infer there." ;
+                rdfs:label "DNA sequence data" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0001580
+obo:OBI_0001580 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0001528 ;
+                obo:IAO_0000111 "material transport service" ;
+                obo:IAO_0000112 "A service for chemical disposal" ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "A service in which a service provider facilitates the transport of some material entity to a specified destination for the service consumer." ;
+                obo:IAO_0000117 "PERSON: Carlo Torniai" ,
+                                "PERSON: Matthew Brush" ;
+                obo:IAO_0000119 "PERSON: Carlo Torniai" ;
+                rdfs:label "material transport service" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0001598
+obo:OBI_0001598 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0001530 ;
+                obo:IAO_0000111 "data maintenance service" ;
+                obo:IAO_0000112 "A database management service, a web hosting service." ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "A maintenance service in which a service provider actively manages or maintains data or a database for the service consumer.  Maintenance of the data is performed to maintain its integrity or enhance its quality or utility for the consumer, but new data is not generated as a result of the maintenance." ;
+                obo:IAO_0000117 "PERSON: Carlo Torniai" ,
+                                "PERSON: Matthew Brush" ;
+                obo:IAO_0000119 "PERSON: Matthew Brush" ;
+                rdfs:label "data maintenance service" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0001615
+obo:OBI_0001615 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0001898 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:IAO_0000136 ;
+                                  owl:someValuesFrom obo:OBI_0000066
+                                ] ;
+                obo:IAO_0000111 "investigation description"@en ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A textual entity that describes an investigation."@en ;
+                obo:IAO_0000117 "Person: Chris Stoeckert, Jie Zheng"@en ;
+                obo:IAO_0000119 "NIAID GSCID-BRC metadata working group"@en ;
+                obo:OBI_0001847 "study description" ;
+                obo:OBI_0001886 "project description"@en ;
+                dc:source "NIAID GSCID-BRC" ;
+                rdfs:label "investigation description"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0001616
+obo:OBI_0001616 rdf:type owl:Class ;
+                rdfs:subClassOf obo:IAO_0000577 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:IAO_0000219 ;
+                                  owl:allValuesFrom obo:OBI_0100051
+                                ] ;
+                obo:IAO_0000111 "specimen identifier"@en ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A CRID symbol denotes a specimen and used to distinguish one specimen from another in an investigation."@en ;
+                obo:IAO_0000117 "Person: Chris Stoeckert, Jie Zheng"@en ;
+                obo:IAO_0000118 "specimen ID"@en ;
+                obo:IAO_0000119 "NIAID GSCID-BRC metadata working group"@en ;
+                obo:OBI_0001886 "Specimen ID" ;
+                dc:source "NIAID GSCID-BRC" ;
+                rdfs:label "specimen identifier"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0001617
+obo:OBI_0001617 rdf:type owl:Class ;
+                rdfs:subClassOf obo:IAO_0000577 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:IAO_0000219 ;
+                                  owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
+                                  owl:onClass obo:IAO_0000311
+                                ] ;
+                obo:IAO_0000111 "PubMed ID"@en ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A CRID symbol that is sufficient to look up a citation from the PubMed, a literature database of life sciences and biomedical information."@en ;
+                obo:IAO_0000116 "Edits was made on Aug 24, 2016 based on OBI dev call, details see tracker: https://sourceforge.net/p/obi/obi-terms/819/" ;
+                obo:IAO_0000117 "Person: Chris Stoeckert, Jie Zheng"@en ;
+                obo:IAO_0000118 "PMID"@en ,
+                                "PubMed Identifier"@en ;
+                obo:IAO_0000119 "Website: http://en.wikipedia.org/wiki/Wikipedia:PMID"@en ;
+                obo:OBI_0001886 "Publication Citation" ;
+                dc:source "NIAID GSCID-BRC" ;
+                rdfs:label "PubMed ID"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0001619
+obo:OBI_0001619 rdf:type owl:Class ;
+                rdfs:subClassOf obo:IAO_0000416 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:IAO_0000136 ;
+                                  owl:someValuesFrom [ owl:intersectionOf ( obo:BFO_0000035
+                                                                            [ rdf:type owl:Restriction ;
+                                                                              owl:onProperty obo:RO_0002223 ;
+                                                                              owl:someValuesFrom obo:OBI_0000659
+                                                                            ]
+                                                                          ) ;
+                                                       rdf:type owl:Class
+                                                     ]
+                                ] ;
+                obo:IAO_0000111 "specimen collection time measurement datum"@en ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A time measurement datum that is the measure of the time when the specimens are collected."@en ;
+                obo:IAO_0000117 "Person: Chris Stoeckert, Jie Zheng"@en ;
+                obo:IAO_0000118 "collection date"@en ;
+                obo:IAO_0000119 "NIAID GSCID-BRC metadata working group"@en ;
+                obo:OBI_0001886 "Specimen Collection Date" ;
+                dc:source "NIAID GSCID-BRC" ;
+                rdfs:label "specimen collection time measurement datum"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0001622
+obo:OBI_0001622 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0001898 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:IAO_0000219 ;
+                                  owl:someValuesFrom obo:OBI_0000066
+                                ] ;
+                obo:IAO_0000111 "investigation title"@en ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A textual entity that denotes an investigation."@en ;
+                obo:IAO_0000117 "Person:Chris Stoeckert, Jie Zheng"@en ;
+                obo:IAO_0000119 "NIAID GSCID-BRC metadata working group"@en ;
+                obo:OBI_0001847 "study title" ;
+                obo:OBI_0001886 "project title"@en ;
+                dc:source "NIAID GSCID-BRC" ;
+                rdfs:label "investigation title"@en .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0001627
+obo:OBI_0001627 rdf:type owl:Class ;
+                rdfs:subClassOf obo:IAO_0000300 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:IAO_0000219 ;
+                                  owl:someValuesFrom obo:GAZ_00000448
+                                ] ;
+                obo:IAO_0000111 "country name"@en ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A textual entity that denotes a geographic location that is a site or part of a site that is identified as a country in the political geography."@en ;
+                obo:IAO_0000117 "Person: Chris Stoeckert, Jie Zheng"@en ;
+                obo:IAO_0000119 "NIAID GSCID-BRC metadata working group"@en ,
+                                "Website: http://en.wikipedia.org/wiki/Country"@en ;
+                obo:OBI_0001886 "Specimen Collection Location - Country" ;
+                dc:source "NIAID GSCID-BRC" ;
+                rdfs:label "country name"@en .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0001628
+obo:OBI_0001628 rdf:type owl:Class ;
+                rdfs:subClassOf obo:IAO_0000577 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:IAO_0000219 ;
+                                  owl:allValuesFrom obo:OBI_0000066
+                                ] ;
+                obo:IAO_0000111 "investigation identifier"@en ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A CRID symbol used to identify an investigation."@en ;
+                obo:IAO_0000117 "Person: Chris Stoeckert, Jie Zhneg"@en ;
+                obo:IAO_0000119 "NIAID GSCID-BRC metadata working group"@en ;
+                obo:OBI_0001886 "project ID"@en ;
+                dc:source "NIAID GSCID-BRC" ;
+                rdfs:label "investigation identifier"@en .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0001629
+obo:OBI_0001629 rdf:type owl:Class ;
+                rdfs:subClassOf obo:IAO_0000577 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:IAO_0000219 ;
+                                  owl:allValuesFrom obo:OBI_0001636
+                                ] ;
+                obo:IAO_0000111 "grant identifier"@en ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A CRID symbol used to identify a grant."@en ;
+                obo:IAO_0000117 "Person: Chris Stoeckert, Jie Zheng"@en ;
+                obo:IAO_0000119 "NIAID GSCID-BRC metadata working group"@en ;
+                obo:OBI_0001886 "grant ID"@en ;
+                dc:source "NIAID GSCID-BRC" ;
+                rdfs:label "grant identifier"@en .
+
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0001636
+obo:OBI_0001636 rdf:type owl:Class ;
+                rdfs:subClassOf obo:IAO_0000104 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000050 ;
+                                  owl:someValuesFrom obo:OBI_0500000
+                                ] ;
+                obo:IAO_0000111 "grant"@en ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A plan specification of organization A to give money to organization B so that B conducts investigations. Organization A has funder role and Organization B has research organization role."@en ;
+                obo:IAO_0000116 """Discussed on Feb 13, 2012 dev call. Details see the tracker:
+https://sourceforge.net/tracker/?func=detail&aid=3483338&group_id=177891&atid=886178"""@en ;
+                obo:IAO_0000117 "Group: OBI"@en ;
+                obo:IAO_0000119 "OBI"@en ;
+                obo:IAO_0000232 "AR: Grant isn't a plan specification, it has a part which is a plan specification. See tracker: https://sourceforge.net/tracker/?func=detail&aid=3483338&group_id=177891&atid=886178" ;
+                rdfs:label "grant"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0001755
+obo:OBI_0001755 rdf:type owl:Class ;
+                rdfs:subClassOf obo:IAO_0000033 ;
+                obo:IAO_0000111 "selection criterion"@en ;
+                obo:IAO_0000112 "rats should be aged between 6 and 8 weeks and weight between 180-250grams"@en ;
+                obo:IAO_0000114 obo:IAO_0000122 ;
+                obo:IAO_0000115 "A directive information entity which defines and states a principle of standard by which selection process may take place."@en ;
+                obo:IAO_0000117 "Person: Philippe Rocca-Serra"@en ;
+                obo:IAO_0000118 "selection rule"@en ;
+                obo:IAO_0000119 "OBI discussion summarized under the following tracker item : http://sourceforge.net/p/obi/obi-terms/678/"@en ;
+                rdfs:label "selection criterion"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0001769
+obo:OBI_0001769 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000202 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:RO_0000052 ;
+                                  owl:someValuesFrom [ owl:intersectionOf ( [ rdf:type owl:Class ;
+                                                                              owl:unionOf ( obo:NCBITaxon_9606
+                                                                                            obo:OBI_0000245
+                                                                                          )
+                                                                            ]
+                                                                            [ rdf:type owl:Restriction ;
+                                                                              owl:onProperty obo:RO_0000053 ;
+                                                                              owl:someValuesFrom [ rdf:type owl:Restriction ;
+                                                                                                   owl:onProperty obo:RO_0000059 ;
+                                                                                                   owl:someValuesFrom [ owl:intersectionOf ( obo:OBI_0000684
+                                                                                                                                             [ rdf:type owl:Restriction ;
+                                                                                                                                               owl:onProperty obo:OBI_0000833 ;
+                                                                                                                                               owl:someValuesFrom [ owl:intersectionOf ( obo:OBI_0000659
+                                                                                                                                                                                         [ rdf:type owl:Restriction ;
+                                                                                                                                                                                           owl:onProperty obo:BFO_0000050 ;
+                                                                                                                                                                                           owl:someValuesFrom obo:OBI_0000066
+                                                                                                                                                                                         ]
+                                                                                                                                                                                       ) ;
+                                                                                                                                                                    rdf:type owl:Class
+                                                                                                                                                                  ]
+                                                                                                                                             ]
+                                                                                                                                           ) ;
+                                                                                                                        rdf:type owl:Class
+                                                                                                                      ]
+                                                                                                 ]
+                                                                            ]
+                                                                          ) ;
+                                                       rdf:type owl:Class
+                                                     ]
+                                ] ;
+                obo:IAO_0000111 "specimen collector role"@en ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 """An Investigation agent role borne by a person or organization which 
+is realized in a specimen collection process.""" ;
+                obo:IAO_0000117 "Person: Jie Zheng, Chris Stoeckert" ;
+                obo:IAO_0000119 "Penn Group" ;
+                dc:source "NIAID GSCID-BRC" ;
+                rdfs:label "specimen collector role"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0001834
+obo:OBI_0001834 rdf:type owl:Class ;
+                owl:equivalentClass [ rdf:type owl:Restriction ;
+                                      owl:onProperty obo:OBI_0000299 ;
+                                      owl:someValuesFrom obo:IAO_0000144
+                                    ] ;
+                rdfs:subClassOf obo:OBI_0000011 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000293 ;
+                                  owl:someValuesFrom obo:IAO_0000030
+                                ] ;
+                obo:IAO_0000111 "drawing a conclusion" ;
+                obo:IAO_0000112 """Concluding that the length of the hypotenuse is equal to the square root of the sum of squares of the other two sides in a right-triangle. 
+Concluding that a gene is upregulated in a tissue sample based on the band intensity in a western blot.  Concluding that a patient has a infection based on measurement of an elevated body temperature and reported headache. Concluding that there were problems in an investigation because data from PCR and microarray are conflicting.""" ;
+                obo:IAO_0000114 obo:IAO_0000123 ;
+                obo:IAO_0000115 "A planned process in which new information is inferred from existing information." ;
+                rdfs:label "drawing a conclusion" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0001868
+obo:OBI_0001868 rdf:type owl:Class ;
+                rdfs:subClassOf obo:CHEBI_33696 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000050 ;
+                                  owl:someValuesFrom [ rdf:type owl:Class ;
+                                                       owl:unionOf ( obo:CL_0000000
+                                                                     obo:NCBITaxon_10239
+                                                                   )
+                                                     ]
+                                ] ;
+                obo:IAO_0000111 "genetic material" ;
+                obo:IAO_0000114 obo:IAO_0000428 ;
+                obo:IAO_0000115 "A nucleic acid macromolecule that is part of a cell or virion and is inherited from an immediate ancestor, or incorporated in a manner that it has the disposition to be replicated and inherited by descendants." ;
+                obo:IAO_0000116 """MHB 3-22-13: Discussions are ongoing about the label of this class, given consideration of a second class that covers nucleic acid parts of cells or virions that participate in gene expression processes as a template for expression or a direct effector of expression of some other genetic element (e.g. an siRNA), but are not necessarily heritable by progeny or inherited from ancestors.  So things like transiently transfected plasmids and siRNAs would qualify as instances of this second class, but not of 'genetic material' as defined here.
+
+Also, OBI needs to import a class representing virions for an axiom on genetic material (part_of some (cell or virion).""" ;
+                obo:IAO_0000118 "genomic material" ,
+                                "hereditary genetic material" ;
+                obo:IAO_0000119 "OBI developer calls, March 4 2013 and March 11 2013" ;
+                rdfs:comment """Naturally occurring or experimentally incorporated nucleic acids that meet these criteria can qualify as genetic/genomic material.
+
+Qualifying examples include: (1) inherited chromosomal DNA in germ cells, stem cells, fully differentiated cells, or cell line cells, or the DNA/RNA content of a virion; (2) natural replicons exchanged through horizontal gene transfer mechanisms such as bacterial conjugation, which are capable of replication and inheritance by progeny; (3) a chromosomally integrated  gene targeting DNA construct transfected into a cell; or (4) a stable extra-chromosomal replicon delivered into cells, such as a plasmid in bacterial host with ori allowing indefinite propagation.  
+
+Non-qualifying examples include a transiently transfected plasmid or siRNA oligo (as these are not able to be replicated and inherited by progeny cells).""" ;
+                rdfs:label "genetic material" .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0001873
+obo:OBI_0001873 rdf:type owl:Class ;
+                rdfs:subClassOf obo:IAO_0000027 ,
+                                obo:OBI_0001933 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:IAO_0000136 ;
+                                  owl:someValuesFrom obo:BFO_0000015
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0001937 ;
+                                  owl:someValuesFrom xsd:integer
+                                ] ;
+                obo:IAO_0000111 "number of errors"@en ;
+                obo:IAO_0000112 """Gigascience. 2012 Dec 27;1(1):18. doi: 10.1186/2047-217X-1-18.
+PMID: 23587118. see table2"""@en ;
+                obo:IAO_0000114 obo:IAO_0000122 ;
+                obo:IAO_0000115 "a data item that is the number of times that a given process failed, as an integer"@en ;
+                obo:IAO_0000117 "Alejandra Gonzalez-Beltran" ,
+                                "Philippe Rocca-Serra" ;
+                obo:IAO_0000119 "PRS, AGB"@en ;
+                rdfs:label "number of errors"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0001874
+obo:OBI_0001874 rdf:type owl:Class ;
+                rdfs:subClassOf obo:IAO_0000032 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:IAO_0000136 ;
+                                  owl:someValuesFrom [ owl:intersectionOf ( obo:OBI_0001877
+                                                                            [ rdf:type owl:Restriction ;
+                                                                              owl:onProperty obo:BFO_0000050 ;
+                                                                              owl:someValuesFrom obo:OBI_0400107
+                                                                            ]
+                                                                          ) ;
+                                                       rdf:type owl:Class
+                                                     ]
+                                ] ;
+                obo:IAO_0000111 "random access memory size"@en ;
+                obo:IAO_0000112 """Gigascience. 2012 Dec 27;1(1):18. doi: 10.1186/2047-217X-1-18.
+PMID: 23587118.
+\"However, the error correction module in SOAPdenovo was designed for short Illumina reads (35-50 bp), which consumes an excessive amount of computational time and memory on longer reads, for example, over 150 GB memory running for two days using 40-fold 100 bp paired-end Illumina HiSeq 2000 reads\""""@en ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "random access memory size is a scalar measurement datum which denotes the amount of physical memory know as random access memory present of a computer or required by a computational process or data transformation"@en ;
+                obo:IAO_0000117 "Alejandra Gonzalez-Beltran"@en ,
+                                "Philippe Rocca-Serra"@en ;
+                obo:IAO_0000119 "PRS, AGB"@en ;
+                rdfs:label "random access memory size"@en .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0001877
+obo:OBI_0001877 rdf:type owl:Class ;
+                rdfs:subClassOf obo:IAO_0000178 ;
+                obo:IAO_0000111 "random access memory"@en ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "Random-access memory (RAM) is a form of computer data storage. A random-access device allows stored data to be accessed directly in any random order. In contrast, other data storage media such as hard disks, CDs, DVDs and magnetic tape, as well as early primary memory types such as drum memory, read and write data only in a predetermined order, consecutively, because of mechanical design limitations. Therefore, the time to access a given data location varies significantly depending on its physical location"@en ;
+                obo:IAO_0000117 "Alejandra Gonzalez-Beltran"@en ,
+                                "Philippe Rocca-Serra"@en ;
+                obo:IAO_0000118 "RAM"@en ;
+                obo:IAO_0000119 """http://en.wikipedia.org/wiki/RAM
+last accessed: 2013-12-02"""@en ;
+                rdfs:label "random access memory"@en .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0001879
+obo:OBI_0001879 rdf:type owl:Class ;
+                owl:equivalentClass [ owl:intersectionOf ( obo:BFO_0000040
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty obo:RO_0000087 ;
+                                                             owl:someValuesFrom obo:OBI_0000086
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf obo:OBI_0000047 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000312 ;
+                                  owl:someValuesFrom obo:OBI_0000094
+                                ] ;
+                obo:IAO_0000111 "reagent"@en ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A biological or chemical entity that bears a reagent role in virtue of it being intended for application in a scientific technique  to participate in (or have molecular parts that participate in) a chemical reaction that facilitates the generation of data about some distinct entity, or the generation of some distinct material specified output." ;
+                obo:IAO_0000116 "2013-6-5 MHB: Clarifications regarding the distinction between reagetns and devices were made at the May 2013 Philly Workshop. Reagents are distinguished from devices that also participate in scientific techniques by the fact that reagents are chemical or biological in nature and necessarily participate in some chemical interaction or reaction during the realization of their experimental role. By contrast, devices do not participate in such chemical reactions/interactions.  Note that there are cases where devices use reagent components during their operation, where the reagent-device distinction is less clear.  For examples, see editor note on OBI:device." ;
+                obo:IAO_0000117 "PERSON:Matthew Brush" ;
+                obo:IAO_0000119 "PERSON:Matthew Brush" ;
+                rdfs:comment """(copied from ReO)
+Reagents are distinguished from devices/instruments that also serve as facilitators in scientific techniques by the fact that reagents are chemical or biological in nature and necessarily participate in or have parts that participate in some chemical interaction or reaction during their intended participation in some technique.  By contrast, devices do not participate in a chemical reaction/interaction during the technique.
+
+Reagents are distinguished from study subjects/evaluants in that study subjects and evaluants are that about which conclusions are drawn and knowledge is sought in an investigation - while reagents, by definition, are not.  It should be noted, however, that reagent and study subject/evaluant roles can be borne by instances of the same type of material entity - but a given instance can only realize one of these roles in the execution of a given  assay. For example, taq polymerase can bear a reagent role or an evaluant role.  In a DNA sequencing assay aimed at generating sequence data about some plasmid, the reagent role of the taq polymerase is realized. In an assay to evaluate the quality of the taq polymerase itself, the evaluant/study subject role of the taq is realized, but not the reagent role since the taq is the subject about which data is generated.
+
+In regard to the statement that reagents are 'distinct' from the specified outputs of a technique:  note that a reagent may be incorporated into a material output of a technique, as long as the IDENTITY of this output is distinct from that of the bearer of the reagent role.  For example, dNTPs input into a PCR are reagents that become part of the material output of this technique, but this output has a new identity (ie that of a 'nucleic acid molecule') that is distinct from the identity of the dNTPs that comprise it.  Similarly, a biotin molecule input into a cell labeling technique are reagents that become part of the specified output, but the identity of the output is that of some modified cell specimen which shares identity with the input unmodified cell specimen, and not with the biotin label. Thus, we see that an important criteria of 'reagent-ness' is that it is a facilitator, and not the primary focus of an investigation or material processing technique (ie not the specified subject/evaluant about which knowledge is sought, or the specified output material of the technique).""" ;
+                rdfs:label "reagent"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0001882
+obo:OBI_0001882 rdf:type owl:Class ;
+                rdfs:subClassOf obo:IAO_0000104 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000050 ;
+                                  owl:someValuesFrom obo:OBI_0500000
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:IAO_0000136 ;
+                                  owl:someValuesFrom [ owl:intersectionOf ( obo:OBI_0000423
+                                                                            [ rdf:type owl:Restriction ;
+                                                                              owl:onProperty obo:OBI_0000312 ;
+                                                                              owl:someValuesFrom [ owl:intersectionOf ( obo:OBI_0302884
+                                                                                                                        [ rdf:type owl:Restriction ;
+                                                                                                                          owl:onProperty obo:OBI_0000293 ;
+                                                                                                                          owl:someValuesFrom obo:OBI_0100051
+                                                                                                                        ]
+                                                                                                                      ) ;
+                                                                                                   rdf:type owl:Class
+                                                                                                 ]
+                                                                            ]
+                                                                          ) ;
+                                                       rdf:type owl:Class
+                                                     ]
+                                ] ;
+                obo:IAO_0000111 "target material in specimen specification"@en ;
+                obo:IAO_0000112 "Some examples of target material are Genome, Purified chromosome, Transcriptome, Phenotype, Proteome." ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A plan specification which specifies the type of material that will be assayed in an investigation." ;
+                obo:IAO_0000117 "PERSON: Chris Stoeckert, Jie Zheng" ;
+                obo:IAO_0000119 "NIAID GSCID-BRC metadata working group" ;
+                obo:OBI_0001886 "Target Material" ;
+                dc:source "NIAID GSCID-BRC" ;
+                rdfs:label "target material in specimen specification"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0001885
+obo:OBI_0001885 rdf:type owl:Class ;
+                owl:equivalentClass [ owl:intersectionOf ( obo:OBI_0000245
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty obo:RO_0000087 ;
+                                                             owl:someValuesFrom [ owl:intersectionOf ( obo:OBI_0000947
+                                                                                                       [ rdf:type owl:Restriction ;
+                                                                                                         owl:onProperty obo:BFO_0000054 ;
+                                                                                                         owl:someValuesFrom [ owl:intersectionOf ( obo:OBI_0001557
+                                                                                                                                                   [ rdf:type owl:Restriction ;
+                                                                                                                                                     owl:onProperty obo:OBI_0000293 ;
+                                                                                                                                                     owl:someValuesFrom obo:OBI_0100051
+                                                                                                                                                   ]
+                                                                                                                                                 ) ;
+                                                                                                                              rdf:type owl:Class
+                                                                                                                            ]
+                                                                                                       ]
+                                                                                                     ) ;
+                                                                                  rdf:type owl:Class
+                                                                                ]
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf obo:OBI_0000245 ;
+                obo:IAO_0000111 "specimen repository organization"@en ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "An organization that provides a service to store and distribute specimens" ;
+                obo:IAO_0000117 "PERSON: Chris Stoeckert, Jie Zheng" ;
+                obo:IAO_0000119 "NIAID GSCID-BRC metadata working group" ;
+                obo:OBI_0001886 "Specimen Repository" ;
+                dc:source "NIAID GSCID-BRC" ;
+                rdfs:label "specimen repository organization"@en .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0001890
+obo:OBI_0001890 rdf:type owl:Class ;
+                owl:equivalentClass [ owl:intersectionOf ( obo:IAO_0000429
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty obo:IAO_0000136 ;
+                                                             owl:someValuesFrom obo:OBI_0001895
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf obo:IAO_0000429 ;
+                obo:IAO_0000111 "email address of specimen collector"@en ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "An email address of the person collecting the specimen" ;
+                obo:IAO_0000117 "PERSON: Chris Stoeckert, Jie Zheng" ;
+                obo:IAO_0000119 "NIAID GSCID-BRC metadata working group" ;
+                obo:OBI_0001886 "Specimen Collector's email" ;
+                dc:source "NIAID GSCID-BRC" ;
+                rdfs:label "email address of specimen collector"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0001891
+obo:OBI_0001891 rdf:type owl:Class ;
+                owl:equivalentClass [ owl:intersectionOf ( obo:OBI_0000245
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty obo:RO_0000087 ;
+                                                             owl:someValuesFrom [ owl:intersectionOf ( obo:OBI_0000947
+                                                                                                       [ rdf:type owl:Restriction ;
+                                                                                                         owl:onProperty obo:BFO_0000054 ;
+                                                                                                         owl:someValuesFrom obo:OBI_0001904
+                                                                                                       ]
+                                                                                                     ) ;
+                                                                                  rdf:type owl:Class
+                                                                                ]
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf obo:OBI_0002198 ;
+                obo:IAO_0000111 "sequencing facility organization"@en ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "An organization that provides sequence determination service" ;
+                obo:IAO_0000117 "PERSON: Chris Stoeckert, Jie Zheng" ;
+                obo:IAO_0000119 "NIAID GSCID-BRC metadata working group" ;
+                obo:OBI_0001886 "Sequencing Facility" ;
+                dc:source "NIAID GSCID-BRC" ;
+                rdfs:label "sequencing facility organization"@en .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0001893
+obo:OBI_0001893 rdf:type owl:Class ;
+                owl:equivalentClass [ owl:intersectionOf ( obo:OBI_0000245
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty obo:OBI_0001688 ;
+                                                             owl:someValuesFrom obo:OBI_0001895
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf obo:OBI_0000245 ;
+                obo:IAO_0000111 "organization of specimen collector"@en ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "An organization that is the affiliation of the person collecting the specimen" ;
+                obo:IAO_0000117 "PERSON: Chris Stoeckert, Jie Zheng" ;
+                obo:IAO_0000119 "NIAID GSCID-BRC metadata working group" ;
+                obo:OBI_0001886 "Specimen Collector's Institution" ;
+                dc:source "NIAID GSCID-BRC" ;
+                rdfs:label "organization of specimen collector"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0001895
+obo:OBI_0001895 rdf:type owl:Class ;
+                owl:equivalentClass [ owl:intersectionOf ( obo:NCBITaxon_9606
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty obo:RO_0000087 ;
+                                                             owl:someValuesFrom obo:OBI_0001769
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf obo:NCBITaxon_9606 ;
+                obo:IAO_0000111 "specimen collector"@en ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A person who collects the specimen" ;
+                obo:IAO_0000117 "PERSON: Chris Stoeckert, Jie Zheng" ;
+                obo:IAO_0000119 "NIAID GSCID-BRC metadata working group" ;
+                obo:OBI_0001886 "Specimen Collector Name" ;
+                dc:source "NIAID GSCID-BRC" ;
+                rdfs:label "specimen collector"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0001900
+obo:OBI_0001900 rdf:type owl:Class ;
+                owl:equivalentClass [ owl:intersectionOf ( obo:OBI_0001616
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty obo:OBI_0000312 ;
+                                                             owl:someValuesFrom [ owl:intersectionOf ( obo:IAO_0000574
+                                                                                                       [ rdf:type owl:Restriction ;
+                                                                                                         owl:onProperty obo:RO_0000057 ;
+                                                                                                         owl:someValuesFrom obo:OBI_0001885
+                                                                                                       ]
+                                                                                                     ) ;
+                                                                                  rdf:type owl:Class
+                                                                                ]
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf obo:OBI_0001616 ;
+                obo:IAO_0000111 "specimen identifier assigned by specimen repository"@en ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A specimen identifier which is assigned by a specimen repository" ;
+                obo:IAO_0000117 "PERSON: Chris Stoeckert, Jie Zheng" ;
+                obo:IAO_0000119 "NIAID GSCID-BRC metadata working group" ;
+                obo:OBI_0001886 "Specimen Repository Sample ID" ;
+                dc:source "NIAID GSCID-BRC" ;
+                rdfs:label "specimen identifier assigned by specimen repository"@en .
+
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0001901
+obo:OBI_0001901 rdf:type owl:Class ;
+                owl:equivalentClass [ owl:intersectionOf ( obo:OBI_0001616
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty obo:OBI_0000312 ;
+                                                             owl:someValuesFrom [ owl:intersectionOf ( obo:IAO_0000574
+                                                                                                       [ rdf:type owl:Restriction ;
+                                                                                                         owl:onProperty obo:RO_0000057 ;
+                                                                                                         owl:someValuesFrom obo:OBI_0001891
+                                                                                                       ]
+                                                                                                     ) ;
+                                                                                  rdf:type owl:Class
+                                                                                ]
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf obo:OBI_0001616 ;
+                obo:IAO_0000111 "specimen identifier assigned by sequencing facility"@en ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A specimen identifier which is assigned by a sequencing facility" ;
+                obo:IAO_0000117 "PERSON: Chris Stoeckert, Jie Zheng" ;
+                obo:IAO_0000119 "NIAID GSCID-BRC metadata working group" ;
+                obo:OBI_0001886 "Sample ID - Sequencing Facility" ;
+                dc:source "NIAID GSCID-BRC" ;
+                rdfs:label "specimen identifier assigned by sequencing facility"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0001902
+obo:OBI_0001902 rdf:type owl:Class ;
+                owl:equivalentClass [ owl:intersectionOf ( obo:OBI_0000073
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty obo:OBI_0000293 ;
+                                                             owl:someValuesFrom [ owl:intersectionOf ( obo:OBI_0100051
+                                                                                                       [ rdf:type owl:Restriction ;
+                                                                                                         owl:onProperty obo:OBI_0000643 ;
+                                                                                                         owl:someValuesFrom obo:CHEBI_33696
+                                                                                                       ]
+                                                                                                     ) ;
+                                                                                  rdf:type owl:Class
+                                                                                ]
+                                                           ]
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty obo:OBI_0000299 ;
+                                                             owl:someValuesFrom [ owl:intersectionOf ( obo:OBI_0100051
+                                                                                                       [ rdf:type owl:Restriction ;
+                                                                                                         owl:onProperty obo:OBI_0000295 ;
+                                                                                                         owl:someValuesFrom obo:OBI_0600047
+                                                                                                       ]
+                                                                                                     ) ;
+                                                                                  rdf:type owl:Class
+                                                                                ]
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf obo:OBI_0000073 ;
+                obo:IAO_0000111 "sample preparation for sequencing assay"@en ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A sample preparation for assay that preparation of nucleic acids for a sequencing assay" ;
+                obo:IAO_0000117 "PERSON: Chris Stoeckert, Jie Zheng" ;
+                obo:IAO_0000119 "NIAID GSCID-BRC metadata working group" ;
+                obo:OBI_0001886 "Nucleic Acid Preparation Method" ;
+                dc:source "NIAID GSCID-BRC" ;
+                rdfs:label "sample preparation for sequencing assay"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0001904
+obo:OBI_0001904 rdf:type owl:Class ;
+                owl:equivalentClass [ owl:intersectionOf ( obo:OBI_0001528
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty obo:OBI_0000107 ;
+                                                             owl:someValuesFrom obo:OBI_0600047
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf obo:OBI_0001547 ;
+                obo:IAO_0000111 "sequencing service"@en ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A service provides sequencing service which is the realization of some sequencing such as RNA and DNA sequencing in which the service provider role is realized." ;
+                obo:IAO_0000117 "Person: Jie Zheng" ;
+                obo:IAO_0000119 "Adpated from 'DNA sequencing service'" ;
+                dc:source "NIAID GSCID-BRC" ;
+                rdfs:label "sequencing service"@en .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0001908
+obo:OBI_0001908 rdf:type owl:Class ;
+                rdfs:subClassOf obo:IAO_0000030 ;
+                obo:IAO_0000111 "testable hypothesis" ;
+                obo:IAO_0000112 "that fucoidan has a small statistically significant effect on AT3 level but no useful clinical effect as in-vivo anticoagulant, a paraphrase of part of the last paragraph of the discussion section of the paper 'Pilot clinical study to evaluate the anticoagulant activity of fucoidan', by Lowenthal et. al.PMID:19696660" ;
+                obo:IAO_0000114 obo:IAO_0000122 ;
+                obo:IAO_0000115 "An information content entity that expresses an assertion that is intended to be tested." ;
+                obo:IAO_0000116 "In the Philly 2013 workshop, we recognized the limitations of \"hypothesis textual entity\", and we introduced this as more general. The need for the 'textual entity' term going forward is up for future debate." ;
+                obo:IAO_0000117 "Group:2013 Philly Workshop group" ;
+                obo:IAO_0000118 "hypothesis" ;
+                obo:IAO_0000119 "Group:2013 Philly Workshop group" ;
+                rdfs:label "testable hypothesis" .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0001909
+obo:OBI_0001909 rdf:type owl:Class ;
+                rdfs:subClassOf obo:IAO_0000030 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000124 ;
+                                  owl:someValuesFrom obo:IAO_0000027
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000312 ;
+                                  owl:someValuesFrom obo:OBI_0000338
+                                ] ;
+                obo:IAO_0000111 "conclusion based on data" ;
+                obo:IAO_0000112 """The conclusion that a gene is upregulated in a tissue sample based on the band intensity in a western blot. The conclusion that a patient has a infection based on measurement of an elevated body temperature and reported headache. The conclusion that there were problems in an investigation because data from PCR and microarray are conflicting.
+The following are NOT conclusions based on data: data themselves; results from pure mathematics, e.g. \"13 is prime\".""" ;
+                obo:IAO_0000114 obo:IAO_0000122 ;
+                obo:IAO_0000115 "An information content entity that is inferred from data." ;
+                obo:IAO_0000116 "In the Philly 2013 workshop, we recognized the limitations of \"conclusion textual entity\", and we introduced this as more general. The need for the 'textual entity' term going forward is up for future debate." ;
+                obo:IAO_0000117 "Group:2013 Philly Workshop group" ;
+                obo:IAO_0000119 "Group:2013 Philly Workshop group" ;
+                rdfs:label "conclusion based on data" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0001913
+obo:OBI_0001913 rdf:type owl:Class ;
+                rdfs:subClassOf obo:IAO_0000416 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:IAO_0000413 ;
+                                  owl:someValuesFrom obo:OBI_0200000
+                                ] ;
+                obo:IAO_0000111 "computation run time"@en ;
+                obo:IAO_0000112 """Gigascience. 2012 Dec 27;1(1):18. doi: 10.1186/2047-217X-1-18.
+PMID: 23587118. 
+
+See Table 4"""@en ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "computation run time is a time measurement datum which corresponds the time expressed in second, minute, hour necessary for a computer program to complete a process execution, for example genome assembly. It is an important metrics as it indicates the resource occupancy and computer program efficiency."@en ;
+                obo:IAO_0000117 "Alejandra Gonzalez-Beltran"@en ,
+                                "Philippe Rocca-Serra"@en ;
+                obo:IAO_0000118 "computation run time datum"@en ;
+                obo:IAO_0000119 "PRS,AGB"@en ;
+                rdfs:label "computation run time"@en .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0001928
+obo:OBI_0001928 rdf:type owl:Class ;
+                owl:equivalentClass [ rdf:type owl:Restriction ;
+                                      owl:onProperty obo:BFO_0000055 ;
+                                      owl:someValuesFrom [ rdf:type owl:Restriction ;
+                                                           owl:onProperty obo:RO_0000059 ;
+                                                           owl:someValuesFrom obo:OBI_0001755
+                                                         ]
+                                    ] ;
+                rdfs:subClassOf obo:OBI_0000011 ;
+                obo:IAO_0000111 "selection"@en ;
+                obo:IAO_0000112 "PMID: 24023800.  In this study, a set of eleven genes (VATP16, 60 S, UQCC, SMD3, EF1α, UBQ, SAND, GAPDH, ACT, PsaB, PTB2) was evaluated to identify reference genes during the first hours of interaction (6, 12, 18 and 24 hpi) between two V. vinifera genotypes and P. viticola. Two analyses were used for the selection of reference genes: direct comparison of susceptible, Trincadeira, and resistant, Regent, V. vinifera cultivars at 0 h, 6, 12, 18 and 24 hours post inoculation with P. viticola (genotype effect); and comparison of each genotype with mock inoculated samples during inoculation time-course (biotic stress effect). Three statistical methods were used, GeNorm, NormFinder, and BestKeeper, allowing to identify UBQ, EF1α and GAPDH as the most stable genes for the genotype effect."@en ;
+                obo:IAO_0000114 obo:IAO_0000122 ;
+                obo:IAO_0000115 "A planned process which results in the creation of group of entity from a larger group by the application of predefined criteria."@en ;
+                obo:IAO_0000116 "this term refers to  a planned process and therefore is distinct from the notion of 'natural selection', a process covering the operation of natural causes by which those individuals of a species that are best adapted to the environment tend to be preserved and to transmit their characters, while those less adapted die out, so that in the course of generations the degree of adaptation to the environment tends progressively to increase. (as defined by Oxford English Dictionary)"@en ;
+                obo:IAO_0000117 "Person: Philippe Rocca-Serra"@en ;
+                obo:IAO_0000118 "selection process"@en ;
+                obo:IAO_0000119 "OBI"@en ;
+                rdfs:label "selection"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0001929
+obo:OBI_0001929 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0001931 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0001927 ;
+                                  owl:someValuesFrom obo:PATO_0000125
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:IAO_0000039 ;
+                                  owl:allValuesFrom obo:UO_0000002
+                                ] ;
+                obo:IAO_0000111 "mass value specification" ;
+                obo:IAO_0000114 obo:IAO_0000123 ;
+                obo:IAO_0000115 "A value specification that specifies the mass of some thing." ;
+                obo:IAO_0000117 "PERSON:Bjoern Peters" ;
+                rdfs:label "mass value specification" .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0001930
+obo:OBI_0001930 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0001933 ;
+                obo:IAO_0000111 "categorical value specification" ;
+                obo:IAO_0000114 obo:IAO_0000123 ;
+                obo:IAO_0000115 "A value specification that is specifies one category out of a fixed number of nominal categories" ;
+                obo:IAO_0000117 "PERSON:Bjoern Peters" ;
+                rdfs:label "categorical value specification" .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0001931
+obo:OBI_0001931 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0001933 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:IAO_0000039 ;
+                                  owl:minCardinality "1"^^xsd:nonNegativeInteger
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0001937 ;
+                                  owl:minCardinality "1"^^xsd:nonNegativeInteger
+                                ] ;
+                obo:IAO_0000111 "scalar value specification" ;
+                obo:IAO_0000114 obo:IAO_0000123 ;
+                obo:IAO_0000115 "A value specification that consists of two parts: a numeral and a unit label" ;
+                obo:IAO_0000117 "PERSON:Bjoern Peters" ;
+                rdfs:label "scalar value specification" .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0001932
+obo:OBI_0001932 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000011 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000051 ;
+                                  owl:someValuesFrom [ owl:intersectionOf ( obo:BFO_0000015
+                                                                            [ rdf:type owl:Restriction ;
+                                                                              owl:onProperty obo:OBI_0000299 ;
+                                                                              owl:someValuesFrom [ owl:intersectionOf ( obo:IAO_0000109
+                                                                                                                        [ rdf:type owl:Restriction ;
+                                                                                                                          owl:onProperty obo:IAO_0000136 ;
+                                                                                                                          owl:someValuesFrom [ owl:intersectionOf ( obo:BFO_0000001
+                                                                                                                                                                    [ rdf:type owl:Restriction ;
+                                                                                                                                                                      owl:onProperty [ owl:inverseOf obo:IAO_0000136
+                                                                                                                                                                                     ] ;
+                                                                                                                                                                      owl:someValuesFrom obo:OBI_0001934
+                                                                                                                                                                    ]
+                                                                                                                                                                  ) ;
+                                                                                                                                               rdf:type owl:Class
+                                                                                                                                             ]
+                                                                                                                        ]
+                                                                                                                      ) ;
+                                                                                                   rdf:type owl:Class
+                                                                                                 ]
+                                                                            ]
+                                                                          ) ;
+                                                       rdf:type owl:Class
+                                                     ]
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000293 ;
+                                  owl:someValuesFrom obo:OBI_0001934
+                                ] ;
+                obo:IAO_0000111 "comparing prediction to measurement" ;
+                obo:IAO_0000114 obo:IAO_0000123 ;
+                obo:IAO_0000115 "A planned process in which predicted values for some thing are compared to measured values for that thing." ;
+                rdfs:label "comparing prediction to measurement" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0001933
+obo:OBI_0001933 rdf:type owl:Class ;
+                rdfs:subClassOf obo:IAO_0000030 ;
+                obo:IAO_0000111 "value specification" ;
+                obo:IAO_0000112 "The value of 'positive' in a classification scheme of \"positive or negative\"; the value of '20g' on the quantitative scale of mass." ;
+                obo:IAO_0000114 obo:IAO_0000122 ;
+                obo:IAO_0000115 "An information content entity that specifies a value within a classification scheme or on a quantitative scale." ;
+                obo:IAO_0000116 "This term is currently a descendant of 'information content entity', which requires that it 'is about' something. A value specification of '20g' for a measurement data item of the mass of a particular mouse 'is about' the mass of that mouse. However there are cases where a value specification is not clearly about any particular. In the future we may change 'value specification' to remove the 'is about' requirement." ;
+                obo:IAO_0000117 "PERSON:Bjoern Peters" ;
+                rdfs:label "value specification" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0001934
+obo:OBI_0001934 rdf:type owl:Class ;
+                rdfs:subClassOf obo:IAO_0000030 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000051 ;
+                                  owl:someValuesFrom obo:OBI_0001933
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000051 ;
+                                  owl:someValuesFrom [ owl:intersectionOf ( obo:IAO_0000104
+                                                                            [ rdf:type owl:Restriction ;
+                                                                              owl:onProperty obo:RO_0000059 ;
+                                                                              owl:allValuesFrom [ rdf:type owl:Restriction ;
+                                                                                                  owl:onProperty obo:BFO_0000055 ;
+                                                                                                  owl:someValuesFrom obo:OBI_0001932
+                                                                                                ]
+                                                                            ]
+                                                                          ) ;
+                                                       rdf:type owl:Class
+                                                     ]
+                                ] ;
+                obo:IAO_0000111 "predicted value" ;
+                obo:IAO_0000114 obo:IAO_0000123 ;
+                obo:IAO_0000115 "an information content entity that has been generated by a prediction process in which an estimate of a value of an entity is made which can be measured but without performing such a measurement. The value specification is intended to be close to the value a measurement process would produce modulo a prediction error." ;
+                obo:IAO_0000117 "PERSON:Bjoern Peters" ;
+                rdfs:label "predicted value" .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0001942
+obo:OBI_0001942 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000245 ;
+                obo:IAO_0000111 "grant agency"@en ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "An organization that provides funding support for projects such as investigations." ;
+                obo:IAO_0000117 "PERSON: Jie Zheng, Chris Stoeckert" ;
+                obo:IAO_0000118 "funding organization" ;
+                obo:IAO_0000119 "NIAID GSCID-BRC metadata working group" ;
+                dc:source "NIAID GSCID-BRC" ;
+                rdfs:label "grant agency"@en ;
+                rdfs:seeAlso """'funding organization'
+http://vivoweb.org/ontology/core#FundingOrganization""" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0001943
+obo:OBI_0001943 rdf:type owl:Class ;
+                rdfs:subClassOf obo:IAO_0000104 ;
+                obo:IAO_0000111 "software pipeline"@en ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A plan specification that specifies a chain encoded in software of processing elements (processes, threads, coroutines, etc.), arranged so that the output of each element is the input of the next. Usually some amount of buffering is provided between consecutive elements." ;
+                obo:IAO_0000117 "PERSON: Jie Zheng, Chris Stoeckert" ;
+                obo:IAO_0000119 "WEB: http://en.wikipedia.org/wiki/Pipeline_%28software%29" ;
+                dc:source "NIAID GSCID-BRC" ;
+                rdfs:label "software pipeline"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0001953
+obo:OBI_0001953 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000011 ;
+                obo:IAO_0000111 "freezing"@en ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A planned process in which a material entity has it's temperature lowered to below the freezing point in order to bring it to a state in which it can be maintained at this lower temperature in order to preserve some of its qualities." ;
+                obo:IAO_0000117 "Person: Mathias Brochhausen, Jie Zheng" ;
+                obo:IAO_0000119 "Mathias Brochhausen" ;
+                rdfs:label "freezing"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0001957
+obo:OBI_0001957 rdf:type owl:Class ;
+                owl:equivalentClass [ owl:intersectionOf ( obo:OBI_0500000
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty obo:BFO_0000051 ;
+                                                             owl:someValuesFrom obo:OBI_0000134
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf obo:OBI_0500000 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000051 ;
+                                  owl:someValuesFrom [ owl:intersectionOf ( obo:OBI_0000750
+                                                                            [ rdf:type owl:Restriction ;
+                                                                              owl:onProperty obo:IAO_0000136 ;
+                                                                              owl:someValuesFrom obo:OBI_0000968
+                                                                            ]
+                                                                          ) ;
+                                                       rdf:type owl:Class
+                                                     ]
+                                ] ;
+                obo:IAO_0000111 "hardware testing design" ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A study design that aims to compare different types of hardware for performance, reproducibility, accuracy and precision." ;
+                obo:IAO_0000117 "Person: Jie Zheng" ;
+                obo:IAO_0000119 "MO_734 hardware_variation_design" ;
+                rdfs:label "hardware testing design" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0001980
+obo:OBI_0001980 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000070 ,
+                                [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
+                                                         owl:onProperty obo:BFO_0000055 ;
+                                                         owl:someValuesFrom [ owl:intersectionOf ( obo:OBI_0000067
+                                                                                                   [ rdf:type owl:Restriction ;
+                                                                                                     owl:onProperty obo:RO_0000081 ;
+                                                                                                     owl:someValuesFrom obo:OBI_0100026
+                                                                                                   ]
+                                                                                                 ) ;
+                                                                              rdf:type owl:Class
+                                                                            ]
+                                                       ]
+                                                       [ rdf:type owl:Restriction ;
+                                                         owl:onProperty obo:OBI_0000293 ;
+                                                         owl:someValuesFrom [ owl:intersectionOf ( obo:OBI_0100026
+                                                                                                   [ rdf:type owl:Restriction ;
+                                                                                                     owl:onProperty obo:RO_0000087 ;
+                                                                                                     owl:someValuesFrom obo:OBI_0000067
+                                                                                                   ]
+                                                                                                 ) ;
+                                                                              rdf:type owl:Class
+                                                                            ]
+                                                       ]
+                                                     ) ;
+                                  rdf:type owl:Class
+                                ] ;
+                obo:IAO_0000111 "in vivo intervention experiment" ;
+                obo:IAO_0000112 "Comparing the level of allergy symptoms in humans before and post allergy immunotherapy. Testing if injection of a chemical compound into mice will lead to decreased survival." ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "An assay in which the effect of a targeted process (the intervention) on an organism is tested." ;
+                obo:IAO_0000116 "The intervention in an experiment should be modeled accordingly to the intevention carried out in a human cllinical trial, which is currently modeled as 'study intervention'. This touches the boundaries of study vs. assay." ;
+                obo:IAO_0000117 "IEDB" ;
+                obo:IAO_0000119 "IEDB" ;
+                rdfs:label "in vivo intervention experiment" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0001984
+obo:OBI_0001984 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0001980 ;
+                obo:IAO_0000111 "treatment intervention experiment" ;
+                obo:IAO_0000112 "Testing if administering oral histamine-blockers will reduce the number of emergency room visits in severely asthmatic individuals." ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "An in vivo intervention experiment in which the ability of the intervention to reduce or cure the effects of a disease are tested." ;
+                obo:IAO_0000116 "should have treatment as intervention" ;
+                obo:IAO_0000117 "IEDB" ;
+                obo:IAO_0000119 "IEDB" ;
+                rdfs:label "treatment intervention experiment" .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0001985
+obo:OBI_0001985 rdf:type owl:Class ;
+                owl:equivalentClass [ owl:intersectionOf ( obo:OBI_0000443
+                                                           [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
+                                                                                    owl:onProperty obo:BFO_0000055 ;
+                                                                                    owl:someValuesFrom [ owl:intersectionOf ( obo:BFO_0000034
+                                                                                                                              [ rdf:type owl:Restriction ;
+                                                                                                                                owl:onProperty obo:RO_0000052 ;
+                                                                                                                                owl:someValuesFrom obo:OBI_0400147
+                                                                                                                              ]
+                                                                                                                            ) ;
+                                                                                                         rdf:type owl:Class
+                                                                                                       ]
+                                                                                  ]
+                                                                                  [ rdf:type owl:Restriction ;
+                                                                                    owl:onProperty obo:OBI_0000293 ;
+                                                                                    owl:someValuesFrom obo:OBI_0400147
+                                                                                  ]
+                                                                                ) ;
+                                                             rdf:type owl:Class
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf obo:OBI_0000443 ;
+                obo:IAO_0000111 "microarray assay" ;
+                obo:IAO_0000112 "Measuring if sera from an influenza A virus immunizedmouse binds to Hemagglutinin protein that is immobilized on a microarray." ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "An analyte assay where binding of the analyte to immobilized matrix is measured." ;
+                obo:IAO_0000117 "IEDB" ;
+                obo:IAO_0000119 "IEDB" ;
+                rdfs:label "microarray assay" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0002076
+obo:OBI_0002076 rdf:type owl:Class ;
+                owl:equivalentClass [ owl:intersectionOf ( obo:BFO_0000040
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty obo:RO_0002351 ;
+                                                             owl:allValuesFrom obo:OBI_0100051
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf obo:BFO_0000040 ;
+                obo:IAO_0000111 "collection of specimens"@en ;
+                obo:IAO_0000112 "Blood cells collected from multiple donors over the course of a study."@en ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "A material entity that has two or more specimens as its parts."@en ;
+                obo:IAO_0000116 "Details see tracker: https://sourceforge.net/p/obi/obi-terms/778/" ;
+                obo:IAO_0000117 "Person: Chris Stoeckert, Jie Zheng"@en ;
+                obo:IAO_0000119 "OBIB, OBI" ;
+                dc:source "Biobank" ;
+                rdfs:label "collection of specimens"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0002078
+obo:OBI_0002078 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000659 ;
+                obo:IAO_0000111 "specimen set collection process"@en ;
+                obo:IAO_0000112 "Collection of both blood and urine specimens in one clinical visit; Taking out liver and brain specimens during an autopsy."@en ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "A specimen collection process that generates multiple specimens from one source (e.g. one organism) during a time period which for the purpose of the study can be considered to be taken at the same sampling time."@en ;
+                obo:IAO_0000117 "Chris Stoeckert, Jie Zheng"@en ;
+                obo:IAO_0000119 "OBIB, OBI"@en ;
+                rdfs:label "specimen set collection process"@en .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0002079
+obo:OBI_0002079 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0002076 ;
+                obo:IAO_0000111 "specimens collected in one encounter"@en ;
+                obo:IAO_0000112 "Both blood and urine specimens collected in one clinical visit; liver and brain specimens taken during an autopsy."@en ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "A collection of specimens that is collected from one source (e.g. one organism) during a time period which for the purpose of the study can be considered to be taken at the same sampling time."@en ;
+                obo:IAO_0000116 "Details see tracker: https://sourceforge.net/p/obi/obi-terms/778/" ;
+                obo:IAO_0000117 "Person: Chris Stoeckert, Jie Zheng"@en ;
+                obo:IAO_0000118 "specimen set"@en ;
+                obo:IAO_0000119 "OBIB, OBI"@en ;
+                dc:source "Biobank" ;
+                rdfs:label "specimens collected in one encounter"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0002080
+obo:OBI_0002080 rdf:type owl:Class ;
+                owl:equivalentClass [ owl:intersectionOf ( obo:OBI_0002079
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty obo:RO_0001000 ;
+                                                             owl:someValuesFrom [ rdf:type owl:Restriction ;
+                                                                                  owl:onProperty obo:BFO_0000050 ;
+                                                                                  owl:someValuesFrom obo:NCBITaxon_9606
+                                                                                ]
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf obo:OBI_0002079 ;
+                obo:IAO_0000111 "human specimen set"@en ;
+                obo:IAO_0000114 obo:IAO_0000122 ;
+                obo:IAO_0000115 "A specimen set that is collected from one person during a time period which for the purpose of the study can be considered to be taken at the same sampling time."@en ;
+                obo:IAO_0000116 "Details see tracker: https://sourceforge.net/p/obi/obi-terms/778/" ;
+                obo:IAO_0000117 "Person: Chris Stoeckert, Jie Zheng"@en ;
+                obo:IAO_0000119 "Duke Biobank, OBIB, OBI"@en ;
+                dc:source "Biobank" ;
+                rdfs:label "human specimen set"@en .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0002081
+obo:OBI_0002081 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0002076 ;
+                obo:IAO_0000111 "specimens collected longitudinally"@en ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "A collection of specimens that was derived from the same source material entity at different time points in order to observe changes in that entity."@en ;
+                obo:IAO_0000116 "Details see tracker: https://sourceforge.net/p/obi/obi-terms/778/" ;
+                obo:IAO_0000117 "Person: Chris Stoeckert"@en ;
+                obo:IAO_0000119 "Bjoern Peters, OBI"@en ;
+                rdfs:label "specimens collected longitudinally"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0002088
+obo:OBI_0002088 rdf:type owl:Class ;
+                owl:equivalentClass [ owl:intersectionOf ( obo:OBI_0000967
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty obo:RO_0000085 ;
+                                                             owl:someValuesFrom obo:OBI_0002087
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf obo:OBI_0000967 ;
+                obo:IAO_0000111 "specimen container" ;
+                obo:IAO_0000112 "COPAN eSwab, CPT vacutainer, PAXgene Blood DNA tube" ;
+                obo:IAO_0000114 obo:IAO_0000122 ;
+                obo:IAO_0000115 "A container with the function of containing a specimen." ;
+                obo:IAO_0000116 "For details see tracker item: http://sourceforge.net/p/obi/obi-terms/792/" ;
+                obo:IAO_0000117 "Chris Stoeckert" ;
+                obo:IAO_0000119 "Duke Biobank, OBIB" ;
+                rdfs:label "specimen container" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0002089
+obo:OBI_0002089 rdf:type owl:Class ;
+                owl:equivalentClass [ owl:intersectionOf ( obo:OBI_0000967
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty obo:RO_0000085 ;
+                                                             owl:someValuesFrom obo:OBI_0000401
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf obo:OBI_0000967 ,
+                                obo:OBI_0001034 ;
+                obo:IAO_0000111 "physical store" ;
+                obo:IAO_0000112 "a freezer. a humidity controlled box." ;
+                obo:IAO_0000114 obo:IAO_0000122 ;
+                obo:IAO_0000115 "A container with an environmental control function." ;
+                obo:IAO_0000116 "For details see tracker item: http://sourceforge.net/p/obi/obi-terms/793/" ;
+                obo:IAO_0000117 "Chris Stoeckert" ;
+                obo:IAO_0000119 "Duke Biobank, OBIB" ;
+                rdfs:label "physical store" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0002095
+obo:OBI_0002095 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000094 ,
+                                [ owl:intersectionOf ( obo:OBI_0000094
+                                                       [ rdf:type owl:Restriction ;
+                                                         owl:onProperty obo:OBI_0000293 ;
+                                                         owl:someValuesFrom obo:OBI_0100051
+                                                       ]
+                                                       [ rdf:type owl:Restriction ;
+                                                         owl:onProperty obo:OBI_0000299 ;
+                                                         owl:someValuesFrom obo:OBI_0002077
+                                                       ]
+                                                     ) ;
+                                  rdf:type owl:Class
+                                ] ;
+                obo:IAO_0000111 "specimen family creation"@en ;
+                obo:IAO_0000112 "Aliquoting one specimen to multiple tubes, slicing a tissue specimen into multiple sections, processing blood into buffy coat, red cells, and serum."@en ;
+                obo:IAO_0000114 obo:IAO_0000122 ;
+                obo:IAO_0000115 "A material processing that has as its input a specimen and as its output a collection of specimens."@en ;
+                obo:IAO_0000116 "For details see tracker: https://sourceforge.net/p/obi/obi-terms/778/"@en ;
+                obo:IAO_0000117 "Mathias Brochhausen, Chris Stoeckert, Jie Zheng"@en ;
+                obo:IAO_0000119 "OBI, OBIB"@en ;
+                dc:source "Biobank"@en ;
+                rdfs:label "specimen family creation"@en .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0002110
+obo:OBI_0002110 rdf:type owl:Class ;
+                rdfs:subClassOf obo:IAO_0000577 ;
+                obo:IAO_0000111 "digital object identifier"@en ;
+                obo:IAO_0000112 "The doi symbol: \"10.1109/5.771073\" resolves to ieee website: http://ieeexplore.ieee.org/xpl/articleDetails.jsp?reload=true&arnumber=771073" ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A centrally registered identifier symbol used to uniquely identify objects given by International DOI Foundation. The DOI system is particularly used for electronic documents such as journal articles." ;
+                obo:IAO_0000116 """Discussed on Aug 22, 2016 OBI dev call. Details see tracker:
+https://sourceforge.net/p/obi/obi-terms/818/""" ;
+                obo:IAO_0000117 "OBI developers" ;
+                obo:IAO_0000118 "DOI" ;
+                obo:IAO_0000119 """https://en.wikipedia.org/wiki/Digital_object_identifier
+https://www.doi.org/""" ;
+                rdfs:label "digital object identifier"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0002119
+obo:OBI_0002119 rdf:type owl:Class ;
+                owl:equivalentClass [ owl:intersectionOf ( obo:OBI_0000185
+                                                           [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
+                                                                                    owl:onProperty obo:BFO_0000055 ;
+                                                                                    owl:someValuesFrom [ owl:intersectionOf ( obo:BFO_0000034
+                                                                                                                              [ rdf:type owl:Restriction ;
+                                                                                                                                owl:onProperty obo:RO_0000052 ;
+                                                                                                                                owl:someValuesFrom obo:OBI_0400169
+                                                                                                                              ]
+                                                                                                                            ) ;
+                                                                                                         rdf:type owl:Class
+                                                                                                       ]
+                                                                                  ]
+                                                                                  [ rdf:type owl:Restriction ;
+                                                                                    owl:onProperty obo:OBI_0000293 ;
+                                                                                    owl:someValuesFrom obo:OBI_0400169
+                                                                                  ]
+                                                                                ) ;
+                                                             rdf:type owl:Class
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf obo:OBI_0000185 ;
+                obo:IAO_0000111 "microscopy assay" ;
+                obo:IAO_0000112 "Lung, liver, and spleen tissue samples were collected from female BALB/c mice and fixed in 100% formalin solution, embedded in paraffin, sectioned, and stained with hematoxylin and eosin. The stained samples were examined for signs of pathological changes under light microscopy." ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "An imaging assay that utilizes a microscope to magnify features of the visualized material of interest that are not visible to naked eye." ;
+                obo:IAO_0000117 "ImmPort" ;
+                obo:IAO_0000119 "PMID:21685355" ;
+                rdfs:label "microscopy assay" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0002124
+obo:OBI_0002124 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0302887 ,
+                                [ owl:intersectionOf ( obo:OBI_0302887
+                                                       [ rdf:type owl:Restriction ;
+                                                         owl:onProperty obo:OBI_0000293 ;
+                                                         owl:someValuesFrom obo:OMIABIS_0000052
+                                                       ]
+                                                     ) ;
+                                  rdf:type owl:Class
+                                ] ;
+                obo:IAO_0000111 "H&E slide staining"@en ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "A staining using hematoxylin and eosin. The staining is applied to fixed specimens on slides to observe the whole structure and morphology of cells in a tissue; nuclei are stained dark blue/purple while cytoplasm is stained pink."@en ;
+                obo:IAO_0000117 "Chris Stoeckert, Ned Haubein"@en ;
+                obo:IAO_0000119 "http://www.histalim.com/accueil/activities/our-services/histology/hematoxylin-eosin-2/"@en ;
+                rdfs:label "H&E slide staining"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0002125
+obo:OBI_0002125 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OMIABIS_0000052 ,
+                                [ owl:intersectionOf ( obo:OMIABIS_0000052
+                                                       [ rdf:type owl:Restriction ;
+                                                         owl:onProperty obo:OBI_0000312 ;
+                                                         owl:someValuesFrom obo:OBI_0002124
+                                                       ]
+                                                     ) ;
+                                  rdf:type owl:Class
+                                ] ;
+                obo:IAO_0000111 "H&E-stained fixed tissue slide specimen"@en ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "A fixed tissue slide specimen that is the output of H&E slide staining."@en ;
+                obo:IAO_0000117 "Chris Stoeckert, Ned Haubein"@en ;
+                obo:IAO_0000119 "OBIB, OBI"@en ;
+                rdfs:label "H&E-stained fixed tissue slide specimen"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0002138
+obo:OBI_0002138 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0001933 ,
+                                [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
+                                                         owl:onProperty obo:OBI_0001927 ;
+                                                         owl:someValuesFrom obo:PATO_0000146
+                                                       ]
+                                                       [ rdf:type owl:Restriction ;
+                                                         owl:onProperty obo:IAO_0000039 ;
+                                                         owl:allValuesFrom obo:UO_0000005
+                                                       ]
+                                                     ) ;
+                                  rdf:type owl:Class
+                                ] ;
+                obo:IAO_0000111 "temperature value specification" ;
+                obo:IAO_0000114 obo:IAO_0000122 ;
+                obo:IAO_0000115 "A value specification that specifies the temperature of some thing." ;
+                obo:IAO_0000117 "Chris Stoeckert" ;
+                obo:IAO_0000119 "OBI" ;
+                rdfs:label "temperature value specification"@en .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0002139
+obo:OBI_0002139 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0001933 ,
+                                [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
+                                                         owl:onProperty obo:OBI_0001927 ;
+                                                         owl:someValuesFrom obo:PATO_0000918
+                                                       ]
+                                                       [ rdf:type owl:Restriction ;
+                                                         owl:onProperty obo:IAO_0000039 ;
+                                                         owl:allValuesFrom obo:UO_0000095
+                                                       ]
+                                                     ) ;
+                                  rdf:type owl:Class
+                                ] ;
+                obo:IAO_0000111 "volume value specification" ;
+                obo:IAO_0000114 obo:IAO_0000122 ;
+                obo:IAO_0000115 "A value specification that specifies the volume of some thing." ;
+                obo:IAO_0000117 "Chris Stoeckert" ;
+                obo:IAO_0000119 "OBI" ;
+                rdfs:label "volume value specification"@en .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0002140
+obo:OBI_0002140 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000070 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000299 ;
+                                  owl:someValuesFrom [ owl:intersectionOf ( obo:IAO_0000109
+                                                                            [ rdf:type owl:Restriction ;
+                                                                              owl:onProperty obo:OBI_0001938 ;
+                                                                              owl:someValuesFrom obo:OBI_0002138
+                                                                            ]
+                                                                          ) ;
+                                                       rdf:type owl:Class
+                                                     ]
+                                ] ;
+                obo:IAO_0000111 "temperature measurement assay" ;
+                obo:IAO_0000114 obo:IAO_0000122 ;
+                obo:IAO_0000115 "An assay to determine the temperature of an evaluant." ;
+                obo:IAO_0000117 "Bjoern Peters" ,
+                                "Chris Stoeckert" ;
+                obo:IAO_0000119 "OBI" ;
+                rdfs:label "temperature measurement assay" .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0002141
+obo:OBI_0002141 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000070 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000299 ;
+                                  owl:someValuesFrom [ owl:intersectionOf ( obo:IAO_0000109
+                                                                            [ rdf:type owl:Restriction ;
+                                                                              owl:onProperty obo:OBI_0001938 ;
+                                                                              owl:someValuesFrom obo:OBI_0002139
+                                                                            ]
+                                                                          ) ;
+                                                       rdf:type owl:Class
+                                                     ]
+                                ] ;
+                obo:IAO_0000111 "volume measurement assay" ;
+                obo:IAO_0000114 obo:IAO_0000122 ;
+                obo:IAO_0000115 "An assay to determine the volume of an evaluant." ;
+                obo:IAO_0000117 "Bjoern Peters" ,
+                                "Chris Stoeckert" ;
+                obo:IAO_0000119 "OBI" ;
+                rdfs:label "volume measurement assay" .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0002176
+obo:OBI_0002176 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000070 ;
+                obo:IAO_0000111 "electrophysiology assay" ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "An assay that measures the electrical properties of biological cells or tissues. Typically, this assay will generate measurements of voltage changes or electric current (or other associated variables such as impedence or capacitance)." ;
+                obo:IAO_0000116 "Note that electrophysiological manipulations also exist which involve processes that alter the electrophysiological properties of cells and tissues." ;
+                obo:IAO_0000117 "Gully Burns" ;
+                obo:IAO_0000119 "url:https://en.wikipedia.org/wiki/Electrophysiology" ;
+                rdfs:label "electrophysiology assay" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0002177
+obo:OBI_0002177 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000447 ,
+                                [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
+                                                         owl:onProperty obo:BFO_0000055 ;
+                                                         owl:someValuesFrom [ owl:intersectionOf ( obo:BFO_0000034
+                                                                                                   [ rdf:type owl:Restriction ;
+                                                                                                     owl:onProperty obo:RO_0000052 ;
+                                                                                                     owl:someValuesFrom obo:OBI_0001080
+                                                                                                   ]
+                                                                                                 ) ;
+                                                                              rdf:type owl:Class
+                                                                            ]
+                                                       ]
+                                                       [ rdf:type owl:Restriction ;
+                                                         owl:onProperty obo:OBI_0000293 ;
+                                                         owl:someValuesFrom obo:OBI_0001080
+                                                       ]
+                                                     ) ;
+                                  rdf:type owl:Class
+                                ] ;
+                obo:IAO_0000111 "patch clamp assay" ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "An intracellular electrophysiology assay where a glass micropipette is sealed to the surface of the cell membrane as a recording electrode to study ion channel activity. The key distinction of this technique is the electrical resistance of the seal between the cell membrane and the pipette is of the order 10-100 gigaohms, permitting high-resolution current measurements over the cell membrane in several different standard configurations." ;
+                obo:IAO_0000117 "Gully Burns" ;
+                obo:IAO_0000119 "ECO:0006012" ,
+                                "url:http://www.annualreviews.org/doi/pdf/10.1146/annurev.ph.46.030184.002323" ,
+                                "url:https://en.wikipedia.org/wiki/Patch_clamp" ;
+                rdfs:label "patch clamp assay" .
+
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0002178
+obo:OBI_0002178 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0002177 ,
+                                [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
+                                                         owl:onProperty obo:BFO_0000055 ;
+                                                         owl:someValuesFrom [ owl:intersectionOf ( obo:BFO_0000034
+                                                                                                   [ rdf:type owl:Restriction ;
+                                                                                                     owl:onProperty obo:RO_0000052 ;
+                                                                                                     owl:someValuesFrom obo:OBI_0001080
+                                                                                                   ]
+                                                                                                 ) ;
+                                                                              rdf:type owl:Class
+                                                                            ]
+                                                       ]
+                                                       [ rdf:type owl:Restriction ;
+                                                         owl:onProperty obo:OBI_0000293 ;
+                                                         owl:someValuesFrom obo:OBI_0001080
+                                                       ]
+                                                     ) ;
+                                  rdf:type owl:Class
+                                ] ;
+                obo:IAO_0000111 "whole-cell patch clamp assay" ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A patch-clamp assay where the electrode is left in place on the cell, as in cell-attached recordings, but the membrane patch has been perforated, providing access from the interior of the pipette to the intracellular space of the cell. Measurements made with this technique involve recording currents through multiple channels simultaneously, over the membrane of the entire cell." ;
+                obo:IAO_0000117 "Gully Burns" ;
+                obo:IAO_0000119 "ECO:0006015" ,
+                                "url:https://en.wikipedia.org/wiki/Patch_clamp#Whole-cell_recording_or_whole-cell_patch" ;
+                rdfs:label "whole-cell patch clamp assay" .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0002179
+obo:OBI_0002179 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0002177 ,
+                                [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
+                                                         owl:onProperty obo:BFO_0000055 ;
+                                                         owl:someValuesFrom [ owl:intersectionOf ( obo:BFO_0000034
+                                                                                                   [ rdf:type owl:Restriction ;
+                                                                                                     owl:onProperty obo:RO_0000052 ;
+                                                                                                     owl:someValuesFrom obo:OBI_0001080
+                                                                                                   ]
+                                                                                                 ) ;
+                                                                              rdf:type owl:Class
+                                                                            ]
+                                                       ]
+                                                       [ rdf:type owl:Restriction ;
+                                                         owl:onProperty obo:OBI_0000293 ;
+                                                         owl:someValuesFrom obo:OBI_0001080
+                                                       ]
+                                                     ) ;
+                                  rdf:type owl:Class
+                                ] ;
+                obo:IAO_0000111 "cell-attached patch clamp assay" ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A patch-clamp assay where the electrode is left in place on the cell, and the membrane patch has been left intact been perforated. This maintains the separation of the interior of the pipette to the intracellular space of the cell. Measurements made with this technique involve recording currents through multiple channels simultaneously, over the membrane of the entire cell." ;
+                obo:IAO_0000117 "Gully Burns" ;
+                obo:IAO_0000119 "url:https://en.wikipedia.org/wiki/Patch_clamp#Cell-attached_patch" ;
+                rdfs:label "cell-attached patch clamp assay" .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0002180
+obo:OBI_0002180 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0002177 ,
+                                [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
+                                                         owl:onProperty obo:BFO_0000055 ;
+                                                         owl:someValuesFrom [ owl:intersectionOf ( obo:BFO_0000034
+                                                                                                   [ rdf:type owl:Restriction ;
+                                                                                                     owl:onProperty obo:RO_0000052 ;
+                                                                                                     owl:someValuesFrom obo:OBI_0001080
+                                                                                                   ]
+                                                                                                 ) ;
+                                                                              rdf:type owl:Class
+                                                                            ]
+                                                       ]
+                                                       [ rdf:type owl:Restriction ;
+                                                         owl:onProperty obo:OBI_0000293 ;
+                                                         owl:someValuesFrom obo:OBI_0001080
+                                                       ]
+                                                     ) ;
+                                  rdf:type owl:Class
+                                ] ;
+                obo:IAO_0000111 "inside-out patch clamp assay" ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A patch-clamp assay where a patch of the membrane is attached to the patch pipette, detached from the rest of the cell, and the cytosolic surface of the membrane is exposed to the external media, or bath. This provides the experimenter has access to the intracellular surface of the membrane via the bath and can manipulate the environment at the intracellular surface of single ion channels. For example, channels that are activated by intracellular ligands can then be studied through a range of ligand concentrations." ;
+                obo:IAO_0000117 "Gully Burns" ;
+                obo:IAO_0000119 "url:http://www.leica-microsystems.com/science-lab/the-patch-clamp-technique/" ,
+                                "url:https://en.wikipedia.org/wiki/Patch_clamp#Inside-out_patch" ;
+                rdfs:label "inside-out patch clamp assay" .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0002181
+obo:OBI_0002181 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0002177 ,
+                                [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
+                                                         owl:onProperty obo:BFO_0000055 ;
+                                                         owl:someValuesFrom [ owl:intersectionOf ( obo:BFO_0000034
+                                                                                                   [ rdf:type owl:Restriction ;
+                                                                                                     owl:onProperty obo:RO_0000052 ;
+                                                                                                     owl:someValuesFrom obo:OBI_0001080
+                                                                                                   ]
+                                                                                                 ) ;
+                                                                              rdf:type owl:Class
+                                                                            ]
+                                                       ]
+                                                       [ rdf:type owl:Restriction ;
+                                                         owl:onProperty obo:OBI_0000293 ;
+                                                         owl:someValuesFrom obo:OBI_0001080
+                                                       ]
+                                                     ) ;
+                                  rdf:type owl:Class
+                                ] ;
+                obo:IAO_0000111 "outside-out patch clamp assay" ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A patch-clamp assay where a patch of the membrane is attached to the patch pipette. In this configuration, the external surface of the cell membrane is exposed as the outside of the membrane patch relative to the patch electrode. An outside-out patch starts with a gigaohm seal in a whole-cell recording configuration. The electrode is slowly withdrawn from the cell, until a fragment of membrane bulges away from the cell, which detaches and reforms as a convex membrane on the end of the electrode, with the original external surface of the membrane facing outward from the electrode. This provides the experimenter with access to the extracellular surface of the membrane via the bath and can manipulate the environment at the extracellular surface of single ion channels." ;
+                obo:IAO_0000117 "Gully Burns" ;
+                obo:IAO_0000119 "url:http://www.leica-microsystems.com/science-lab/the-patch-clamp-technique/" ,
+                                "url:https://en.wikipedia.org/wiki/Patch_clamp#Outside-out_patch" ;
+                rdfs:label "outside-out patch clamp assay" .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0002182
+obo:OBI_0002182 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000447 ,
+                                [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
+                                                         owl:onProperty obo:BFO_0000055 ;
+                                                         owl:someValuesFrom [ owl:intersectionOf ( obo:BFO_0000034
+                                                                                                   [ rdf:type owl:Restriction ;
+                                                                                                     owl:onProperty obo:RO_0000052 ;
+                                                                                                     owl:someValuesFrom obo:OBI_0001129
+                                                                                                   ]
+                                                                                                 ) ;
+                                                                              rdf:type owl:Class
+                                                                            ]
+                                                       ]
+                                                       [ rdf:type owl:Restriction ;
+                                                         owl:onProperty obo:OBI_0000293 ;
+                                                         owl:someValuesFrom obo:OBI_0001129
+                                                       ]
+                                                     ) ;
+                                  rdf:type owl:Class
+                                ] ;
+                obo:IAO_0000111 "voltage clamp assay" ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "An cellular electrophysiology assay where the membrane potential of a cell is controlled by the experimentalist. This is accomplished through a feedback mechanism where any change in membrane potential is countered by permitting electrical current to flow into or out of the cell." ;
+                obo:IAO_0000117 "Gully Burns" ;
+                obo:IAO_0000119 "url:https://en.wikipedia.org/wiki/Voltage_clamp" ;
+                rdfs:label "voltage clamp assay" .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0002183
+obo:OBI_0002183 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0002182 ,
+                                [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
+                                                         owl:onProperty obo:BFO_0000055 ;
+                                                         owl:someValuesFrom [ owl:intersectionOf ( obo:BFO_0000034
+                                                                                                   [ rdf:type owl:Restriction ;
+                                                                                                     owl:onProperty obo:RO_0000052 ;
+                                                                                                     owl:someValuesFrom obo:OBI_0001129
+                                                                                                   ]
+                                                                                                 ) ;
+                                                                              rdf:type owl:Class
+                                                                            ]
+                                                       ]
+                                                       [ rdf:type owl:Restriction ;
+                                                         owl:onProperty obo:OBI_0000293 ;
+                                                         owl:someValuesFrom obo:OBI_0001129
+                                                       ]
+                                                     ) ;
+                                  rdf:type owl:Class
+                                ] ;
+                obo:IAO_0000111 "two electrode voltage clamp assay" ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "The two electrode voltage clamp (TEVC) method utilizes two low-resistance pipettes, one sensing voltage and the other injecting current. The microelectrodes are filled with conductive solution and inserted into the cell to artificially control membrane potential. The membrane acts as a dielectric as well as a resistor, while the fluids on either side of the membrane function as capacitors.[9] The microelectrodes compare the membrane potential against a command voltage, giving an accurate reproduction of the currents flowing across the membrane. Current readings can be used to analyze the electrical response of the cell to different applications. This technique is mainly used in the Oocyte preparation." ;
+                obo:IAO_0000117 "Gully Burns" ;
+                obo:IAO_0000118 "TEVC" ;
+                obo:IAO_0000119 "url:https://en.wikipedia.org/wiki/Voltage_clamp#Two-electrode_voltage_clamp_using_microelectrodes" ;
+                rdfs:label "two electrode voltage clamp assay" .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0002184
+obo:OBI_0002184 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0002182 ,
+                                [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
+                                                         owl:onProperty obo:BFO_0000055 ;
+                                                         owl:someValuesFrom [ owl:intersectionOf ( obo:BFO_0000034
+                                                                                                   [ rdf:type owl:Restriction ;
+                                                                                                     owl:onProperty obo:RO_0000052 ;
+                                                                                                     owl:someValuesFrom obo:OBI_0001129
+                                                                                                   ]
+                                                                                                 ) ;
+                                                                              rdf:type owl:Class
+                                                                            ]
+                                                       ]
+                                                       [ rdf:type owl:Restriction ;
+                                                         owl:onProperty obo:OBI_0000293 ;
+                                                         owl:someValuesFrom obo:OBI_0001129
+                                                       ]
+                                                     ) ;
+                                  rdf:type owl:Class
+                                ] ;
+                obo:IAO_0000111 "cut open oocyte voltage clamp assay" ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "The cut-open oocyte Vaseline gap (COVG) voltage-clamp technique is designed to solve weaknesses in the two elextrode voltage clamp by maximizing the benefits of the Xenopus oocyte expression system by improving on clamp speed, signal-to-noise ratio, and ability to effectively perfuse the oocyte. In this way, it was possible to combine the most popular transient expression system, and the associated benefits of molecular cloning and site-directed mutagenesis, with the superior voltage-clamp properties of cut-open cell techniques." ;
+                obo:IAO_0000117 "Gully Burns" ;
+                obo:IAO_0000118 "COVG" ;
+                obo:IAO_0000119 "PMID:9711615" ;
+                rdfs:label "cut open oocyte voltage clamp assay" .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0002185
+obo:OBI_0002185 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000447 ;
+                obo:IAO_0000111 "current clamp assay" ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "The current clamp technique records the membrane potential by injecting current into a cell through the recording electrode. Unlike in the voltage clamp mode, where the membrane potential is held at a level determined by the experimenter, in \"current clamp\" mode the membrane potential is free to vary, and the amplifier records whatever voltage the cell generates on its own or as a result of stimulation. This technique is used to study how a cell responds when electric current enters a cell; this is important for instance for understanding how neurons respond to neurotransmitters that act by opening membrane ion channels." ;
+                obo:IAO_0000117 "Gully Burns" ;
+                obo:IAO_0000119 "url:https://en.wikipedia.org/wiki/Electrophysiology#Current_clamp" ;
+                rdfs:label "current clamp assay" .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0002186
+obo:OBI_0002186 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000454 ;
+                obo:IAO_0000111 "electroencephalography" ;
+                obo:IAO_0000114 obo:IAO_0000123 ;
+                obo:IAO_0000115 "An extracellular electrophysiology assay where electrodes are mounted outside the brain (either on the surface of the scalp on onto the brain surface itself during surgery) to measure the electrical field over the external surface." ;
+                obo:IAO_0000117 "Gully Burns" ;
+                obo:IAO_0000118 "EEG" ;
+                rdfs:label "electroencephalography" .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0002187
+obo:OBI_0002187 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000454 ,
+                                obo:OBI_0001977 ,
+                                [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
+                                                         owl:onProperty obo:BFO_0000055 ;
+                                                         owl:someValuesFrom [ owl:intersectionOf ( obo:BFO_0000034
+                                                                                                   [ rdf:type owl:Restriction ;
+                                                                                                     owl:onProperty obo:RO_0000052 ;
+                                                                                                     owl:someValuesFrom obo:OBI_0000816
+                                                                                                   ]
+                                                                                                 ) ;
+                                                                              rdf:type owl:Class
+                                                                            ]
+                                                       ]
+                                                       [ rdf:type owl:Restriction ;
+                                                         owl:onProperty obo:OBI_0000293 ;
+                                                         owl:someValuesFrom obo:OBI_0000816
+                                                       ]
+                                                     ) ;
+                                  rdf:type owl:Class
+                                ] ,
+                                [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
+                                                         owl:onProperty obo:BFO_0000055 ;
+                                                         owl:someValuesFrom [ owl:intersectionOf ( obo:OBI_0000067
+                                                                                                   [ rdf:type owl:Restriction ;
+                                                                                                     owl:onProperty obo:RO_0000081 ;
+                                                                                                     owl:someValuesFrom obo:CL_0000540
+                                                                                                   ]
+                                                                                                 ) ;
+                                                                              rdf:type owl:Class
+                                                                            ]
+                                                       ]
+                                                       [ rdf:type owl:Restriction ;
+                                                         owl:onProperty obo:OBI_0000293 ;
+                                                         owl:someValuesFrom [ owl:intersectionOf ( obo:CL_0000540
+                                                                                                   [ rdf:type owl:Restriction ;
+                                                                                                     owl:onProperty obo:RO_0000087 ;
+                                                                                                     owl:someValuesFrom obo:OBI_0000067
+                                                                                                   ]
+                                                                                                 ) ;
+                                                                              rdf:type owl:Class
+                                                                            ]
+                                                       ]
+                                                     ) ;
+                                  rdf:type owl:Class
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000299 ;
+                                  owl:someValuesFrom [ rdf:type owl:Restriction ;
+                                                       owl:onProperty obo:IAO_0000136 ;
+                                                       owl:someValuesFrom obo:GO_0001508
+                                                     ]
+                                ] ;
+                obo:IAO_0000111 "single-unit recording" ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "An extracellular electrophysiology assay where a single microelectrode is placed in close proximity to a single neuron to measure voltage and current changes over time. This is the technicque used by Hubel and Wiesel to measure firing properties of primary visual cortex neurons in the 1950s in their original Nobel-prize winning study. A classic, old technique." ;
+                obo:IAO_0000116 "Can be used on any cell, not just neurons." ;
+                obo:IAO_0000117 "Gully Burns" ;
+                obo:IAO_0000119 "url:http://www.thieme.com/media/samples/pubid-80418214.pdf" ;
+                rdfs:label "single-unit recording" .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0002188
+obo:OBI_0002188 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000454 ;
+                obo:IAO_0000111 "multi-unit recording" ;
+                obo:IAO_0000114 obo:IAO_0000123 ;
+                obo:IAO_0000115 "An extracellular electrophysiology assay where a collection of microelectrodes (often in an 'array' configuration) is placed into neural tissue to measure the distribution of voltage and current changes for a population of cells over time." ;
+                obo:IAO_0000117 "Gully Burns" ;
+                rdfs:label "multi-unit recording" .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0002189
+obo:OBI_0002189 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000454 ,
+                                [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
+                                                         owl:onProperty obo:BFO_0000055 ;
+                                                         owl:someValuesFrom [ owl:intersectionOf ( obo:BFO_0000034
+                                                                                                   [ rdf:type owl:Restriction ;
+                                                                                                     owl:onProperty obo:RO_0000052 ;
+                                                                                                     owl:someValuesFrom obo:OBI_0000816
+                                                                                                   ]
+                                                                                                 ) ;
+                                                                              rdf:type owl:Class
+                                                                            ]
+                                                       ]
+                                                       [ rdf:type owl:Restriction ;
+                                                         owl:onProperty obo:OBI_0000293 ;
+                                                         owl:someValuesFrom obo:OBI_0000816
+                                                       ]
+                                                     ) ;
+                                  rdf:type owl:Class
+                                ] ,
+                                [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
+                                                         owl:onProperty obo:BFO_0000055 ;
+                                                         owl:someValuesFrom [ owl:intersectionOf ( obo:OBI_0000067
+                                                                                                   [ rdf:type owl:Restriction ;
+                                                                                                     owl:onProperty obo:RO_0000081 ;
+                                                                                                     owl:someValuesFrom [ owl:intersectionOf ( obo:UBERON_0000479
+                                                                                                                                               [ rdf:type owl:Restriction ;
+                                                                                                                                                 owl:onProperty obo:RO_0001025 ;
+                                                                                                                                                 owl:someValuesFrom obo:UBERON_0000955
+                                                                                                                                               ]
+                                                                                                                                             ) ;
+                                                                                                                          rdf:type owl:Class
+                                                                                                                        ]
+                                                                                                   ]
+                                                                                                 ) ;
+                                                                              rdf:type owl:Class
+                                                                            ]
+                                                       ]
+                                                       [ rdf:type owl:Restriction ;
+                                                         owl:onProperty obo:OBI_0000293 ;
+                                                         owl:someValuesFrom [ owl:intersectionOf ( [ owl:intersectionOf ( obo:UBERON_0000479
+                                                                                                                          [ rdf:type owl:Restriction ;
+                                                                                                                            owl:onProperty obo:RO_0001025 ;
+                                                                                                                            owl:someValuesFrom obo:UBERON_0000955
+                                                                                                                          ]
+                                                                                                                        ) ;
+                                                                                                     rdf:type owl:Class
+                                                                                                   ]
+                                                                                                   [ rdf:type owl:Restriction ;
+                                                                                                     owl:onProperty obo:RO_0000087 ;
+                                                                                                     owl:someValuesFrom obo:OBI_0000067
+                                                                                                   ]
+                                                                                                 ) ;
+                                                                              rdf:type owl:Class
+                                                                            ]
+                                                       ]
+                                                     ) ;
+                                  rdf:type owl:Class
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000299 ;
+                                  owl:someValuesFrom [ rdf:type owl:Restriction ;
+                                                       owl:onProperty obo:IAO_0000136 ;
+                                                       owl:someValuesFrom obo:GO_0001508
+                                                     ]
+                                ] ;
+                obo:IAO_0000111 "local field potential recording" ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "An extracellular electrophysiology assay where a microelectrode is placed in the extracellular space of brain tissue to measure action potential and compared to an electrode either outside or inside that tissue." ;
+                obo:IAO_0000117 "Gully Burns" ;
+                obo:IAO_0000119 "doi:10.1007/978-1-4614-7320-6_723-1" ;
+                rdfs:label "local field potential recording" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0002190
+obo:OBI_0002190 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000245 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:RO_0000087 ;
+                                  owl:someValuesFrom [ owl:intersectionOf ( obo:OBI_0000947
+                                                                            [ rdf:type owl:Restriction ;
+                                                                              owl:onProperty obo:BFO_0000054 ;
+                                                                              owl:someValuesFrom obo:OBI_0001580
+                                                                            ]
+                                                                          ) ;
+                                                       rdf:type owl:Class
+                                                     ]
+                                ] ;
+                obo:IAO_0000111 "courier organization" ;
+                obo:IAO_0000114 obo:IAO_0000122 ;
+                obo:IAO_0000115 "An organization that delivers messages, packages, and mail." ;
+                obo:IAO_0000117 "Chris Stoeckert, Helena Ellis" ;
+                obo:IAO_0000118 "courier" ;
+                obo:IAO_0000119 "https://en.wikipedia.org/wiki/Courier" ;
+                obo:IAO_0000234 "NCI BBRB" ;
+                rdfs:label "courier organization"@en .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0002191
+obo:OBI_0002191 rdf:type owl:Class ;
+                rdfs:subClassOf obo:IAO_0000577 ;
+                obo:IAO_0000111 "courier tracking number" ;
+                obo:IAO_0000114 obo:IAO_0000122 ;
+                obo:IAO_0000115 "A centrally registered identifier symbol assigned by a courier organization in order to track the delivery of an item." ;
+                obo:IAO_0000117 "Chris Stoeckert, Helena Ellis" ;
+                obo:IAO_0000119 "OBIB" ;
+                obo:IAO_0000234 "NCI BBRB" ;
+                rdfs:label "courier tracking number"@en .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0002197
+obo:OBI_0002197 rdf:type owl:Class ;
+                rdfs:subClassOf obo:IAO_0000408 ;
+                obo:IAO_0000111 "tissue section thickness" ;
+                obo:IAO_0000114 obo:IAO_0000122 ;
+                obo:IAO_0000115 "A length measurement datum that is the result of an assay measuring the thickness of a tissue section." ;
+                obo:IAO_0000117 "Chris Stoeckert, Helena Ellis" ;
+                obo:IAO_0000119 "NCI BBRB, OBIB" ;
+                obo:IAO_0000234 "NCI BBRB" ;
+                rdfs:label "tissue section thickness"@en .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0002199
+obo:OBI_0002199 rdf:type owl:Class ;
+                rdfs:subClassOf obo:IAO_0000030 ;
+                obo:IAO_0000111 "reason for lack of data item" ;
+                obo:IAO_0000112 "cannot be assessed, not applicable, unknown" ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "An information content entity that provides an explanation why a data item is not provided." ;
+                obo:IAO_0000117 "Chris Stoeckert, Helena Ellis" ;
+                obo:IAO_0000119 "OBI" ;
+                obo:IAO_0000234 "NCI BBRB" ;
+                rdfs:label "reason for lack of data item" .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0002200
+obo:OBI_0002200 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0002199 ;
+                obo:IAO_0000111 "cannot be assessed determination" ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A reason for lack of data item that is the negative output of a determination if assay will provide reliable results." ;
+                obo:IAO_0000117 "Chris Stoeckert, Helena Ellis" ;
+                obo:IAO_0000118 "cannot be assessed" ;
+                obo:IAO_0000119 "OBI" ;
+                obo:IAO_0000234 "NCI BBRB" ;
+                rdfs:label "cannot be assessed determination" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0002441
+obo:OBI_0002441 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000070 ;
+                obo:IAO_0000111 "physical examination of individual" ;
+                obo:IAO_0000114 obo:IAO_0000123 ;
+                obo:IAO_0000115 "An assay that produces a description of the qualities of an entity that has not been transformed, through observation and physical, non-invasive techniques." ;
+                rdfs:label "physical examination of individual" .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0002444
+obo:OBI_0002444 rdf:type owl:Class ;
+                rdfs:subClassOf obo:BFO_0000023 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:RO_0000081 ;
+                                  owl:someValuesFrom obo:BFO_0000040
+                                ] ;
+                obo:IAO_0000111 "measurand role"@en ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A role borne by a material entity and realized in an assay which achieves the objective to measure the magnitude/concentration/amount of the measurand in the entity bearing evaluant role." ;
+                obo:IAO_0000117 "Person: Alan Ruttenberg, Jie Zheng" ;
+                obo:IAO_0000119 "https://en.wiktionary.org/wiki/measurand" ;
+                obo:IAO_0000233 "https://github.com/obi-ontology/obi/issues/778" ;
+                rdfs:label "measurand role"@en .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0002453
+obo:OBI_0002453 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0500027 ;
+                obo:IAO_0000111 "health status inclusion criterion"@en ;
+                obo:IAO_0000112 "‘diagnosed with Type 2 diabetes mellitus’, ‘E11.4’, ’not finding of hypertension'"@en ;
+                obo:IAO_0000114 obo:IAO_0000123 ;
+                obo:IAO_0000115 "An inclusion criterion that defines and states one or more clinically significant bodily components, dispositions, and/or bodily processes of an entity that are inferred from relevant clinical findings or self-reported, which, if met, makes the entity suitable for a given task or participation in a given process."@en ;
+                obo:IAO_0000117 "Mathias Brochhausen"@en ;
+                obo:IAO_0000234 "MIABIS2.0"@en ;
+                rdfs:label "health status inclusion criterion"@en .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0002456
+obo:OBI_0002456 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0500027 ;
+                obo:IAO_0000111 "gravidity inclusion criterion"@en ;
+                obo:IAO_0000112 "'pregnant’, ‘not pregnant'"@en ;
+                obo:IAO_0000114 obo:IAO_0000123 ;
+                obo:IAO_0000115 "An inclusion criterion that defines and states one or more gravidity statuses of an organism, which, if met, makes the entity suitable for a given task or participation in a given process."@en ;
+                obo:IAO_0000117 "Mathias Brochhausen"@en ;
+                obo:IAO_0000234 "MIABIS2.0"@en ;
+                rdfs:label "gravidity inclusion criterion"@en .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0002460
+obo:OBI_0002460 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0500027 ;
+                obo:IAO_0000111 "defined population inclusion criterion" ;
+                obo:IAO_0000112 "inclusion based on age, sex, and living region (rural area or specified city)." ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "An inclusion criterion that is based on fitting within the defined characteristics of a population based study design." ;
+                obo:IAO_0000117 "Chris Stoeckert, Mathias Brochhausen" ;
+                obo:IAO_0000119 "MIABIS 2.0" ;
+                obo:IAO_0000233 "https://github.com/obi-ontology/obi/issues/920" ;
+                obo:IAO_0000234 "MIABIS 2.0" ;
+                rdfs:label "defined population inclusion criterion"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0002471
+obo:OBI_0002471 rdf:type owl:Class ;
+                rdfs:subClassOf obo:IAO_0000027 ;
+                obo:IAO_0000111 "date process started"@en ;
+                obo:IAO_0000114 obo:IAO_0000123 ;
+                obo:IAO_0000115 "A data item that is the date when a process was initiated."@en ;
+                obo:IAO_0000117 "Chris Stoeckert, Daniel Berrios, Stephen A. Fisher"@en ;
+                rdfs:label "date process started"@en .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0002482
+obo:OBI_0002482 rdf:type owl:Class ;
+                rdfs:subClassOf obo:IAO_0000109 ;
+                obo:IAO_0000111 "specimen harvest quantity"@en ;
+                obo:IAO_0000114 obo:IAO_0000123 ;
+                obo:IAO_0000115 "A scalar measurement datum that indicates the amount of specimen collected."@en ;
+                obo:IAO_0000117 "Stephen A. Fisher, Junhyong Kim, Dan Berrios"@en ;
+                obo:IAO_0000118 "harvest quantity"@en ;
+                rdfs:label "specimen harvest quantity"@en .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0002488
+obo:OBI_0002488 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000968 ;
+                obo:IAO_0000111 "pipette" ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A device that is a laboratory tool commonly used in chemistry, biology and medicine to transport a measured volume of liquid, often as a media dispenser." ;
+                obo:IAO_0000117 "Stephen A. Fisher, Junhyong Kim, Dan Berrios" ;
+                obo:IAO_0000119 "https://en.wikipedia.org/wiki/Pipette" ;
+                rdfs:label "pipette" .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0002490
+obo:OBI_0002490 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0001931 ;
+                obo:IAO_0000111 "medication time value specification" ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A scalar value specification that specifies the point in time that a human participant under investigation self-administers a medication material" ;
+                obo:IAO_0000117 "John Judkins" ;
+                obo:IAO_0000118 "medication timepoint" ;
+                obo:IAO_0000119 "OBI" ;
+                obo:IAO_0000234 "VEuPathDB" ;
+                rdfs:label "medication time value specification" .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0002491
+obo:OBI_0002491 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0001931 ;
+                obo:IAO_0000111 "medication dose value specification" ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A scalar value specification that specifies the value of the quantity of a material entity administered to an organism as a treatment" ;
+                obo:IAO_0000117 "John Judkins" ;
+                obo:IAO_0000118 "medication dose" ;
+                obo:IAO_0000119 "OBI" ;
+                obo:IAO_0000234 "VEuPathDB" ;
+                rdfs:label "medication dose value specification" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0002502
+obo:OBI_0002502 rdf:type owl:Class ;
+                owl:equivalentClass [ owl:intersectionOf ( [ owl:intersectionOf ( obo:OBI_0100051
+                                                                                  [ rdf:type owl:Restriction ;
+                                                                                    owl:onProperty obo:OBI_0000312 ;
+                                                                                    owl:someValuesFrom obo:OBI_0000659
+                                                                                  ]
+                                                                                  [ rdf:type owl:Restriction ;
+                                                                                    owl:onProperty obo:RO_0001000 ;
+                                                                                    owl:someValuesFrom obo:UBERON_0001359
+                                                                                  ]
+                                                                                ) ;
+                                                             rdf:type owl:Class
+                                                           ]
+                                                           [ owl:intersectionOf ( obo:OBI_0100051
+                                                                                  [ rdf:type owl:Restriction ;
+                                                                                    owl:onProperty obo:OBI_0000312 ;
+                                                                                    owl:someValuesFrom obo:OBI_0600005
+                                                                                  ]
+                                                                                ) ;
+                                                             rdf:type owl:Class
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf obo:OBI_2000009 ;
+                obo:IAO_0000111 "cerebrospinal fluid specimen" ;
+                obo:IAO_0000114 obo:IAO_0000122 ;
+                obo:IAO_0000115 "A specimen that is derived from cerbrospinal fluid." ;
+                obo:IAO_0000117 "Chris Stoeckert" ;
+                obo:IAO_0000119 "Chris Stoeckert, Penn Medicine Biobank" ;
+                rdfs:label "cerebrospinal fluid specimen" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0002507
+obo:OBI_0002507 rdf:type owl:Class ;
+                owl:equivalentClass [ owl:intersectionOf ( [ owl:intersectionOf ( obo:OBI_0100051
+                                                                                  [ rdf:type owl:Restriction ;
+                                                                                    owl:onProperty obo:OBI_0000312 ;
+                                                                                    owl:someValuesFrom obo:OBI_0000659
+                                                                                  ]
+                                                                                  [ rdf:type owl:Restriction ;
+                                                                                    owl:onProperty obo:RO_0001000 ;
+                                                                                    owl:someValuesFrom obo:UBERON_0001836
+                                                                                  ]
+                                                                                ) ;
+                                                             rdf:type owl:Class
+                                                           ]
+                                                           [ owl:intersectionOf ( obo:OBI_0100051
+                                                                                  [ rdf:type owl:Restriction ;
+                                                                                    owl:onProperty obo:OBI_0000312 ;
+                                                                                    owl:someValuesFrom obo:OBI_0600005
+                                                                                  ]
+                                                                                ) ;
+                                                             rdf:type owl:Class
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf obo:OBI_0001479 ;
+                obo:IAO_0000111 "saliva specimen" ;
+                obo:IAO_0000114 obo:IAO_0000122 ;
+                obo:IAO_0000115 "A specimen that is derived from saliva." ;
+                obo:IAO_0000117 "Chris Stoeckert" ;
+                obo:IAO_0000119 "Chris Stoeckert, Penn Medicine Biobank" ;
+                rdfs:label "saliva specimen" .
+
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0002516
+obo:OBI_0002516 rdf:type owl:Class ;
+                owl:equivalentClass [ owl:intersectionOf ( [ owl:intersectionOf ( obo:OBI_0100051
+                                                                                  [ rdf:type owl:Restriction ;
+                                                                                    owl:onProperty obo:OBI_0000312 ;
+                                                                                    owl:someValuesFrom obo:OBI_0000659
+                                                                                  ]
+                                                                                  [ rdf:type owl:Restriction ;
+                                                                                    owl:onProperty obo:RO_0001000 ;
+                                                                                    owl:someValuesFrom [ owl:intersectionOf ( obo:UBERON_0000479
+                                                                                                                              [ rdf:type owl:Restriction ;
+                                                                                                                                owl:onProperty obo:BFO_0000050 ;
+                                                                                                                                owl:someValuesFrom obo:UBERON_0000955
+                                                                                                                              ]
+                                                                                                                            ) ;
+                                                                                                         rdf:type owl:Class
+                                                                                                       ]
+                                                                                  ]
+                                                                                ) ;
+                                                             rdf:type owl:Class
+                                                           ]
+                                                           [ owl:intersectionOf ( obo:OBI_0100051
+                                                                                  [ rdf:type owl:Restriction ;
+                                                                                    owl:onProperty obo:OBI_0000312 ;
+                                                                                    owl:someValuesFrom obo:OBI_0600005
+                                                                                  ]
+                                                                                ) ;
+                                                             rdf:type owl:Class
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf obo:OBI_0001479 ;
+                obo:IAO_0000111 "brain specimen" ;
+                obo:IAO_0000114 obo:IAO_0000122 ;
+                obo:IAO_0000115 "A specimen that is derived from brain." ;
+                obo:IAO_0000117 "Chris Stoeckert" ;
+                obo:IAO_0000119 "Chris Stoeckert, NCI BBRB" ;
+                rdfs:label "brain specimen" .
+
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0002555
+obo:OBI_0002555 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0500027 ,
+                                [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
+                                                         owl:onProperty obo:BFO_0000051 ;
+                                                         owl:someValuesFrom obo:OBI_0002556
+                                                       ]
+                                                       [ rdf:type owl:Restriction ;
+                                                         owl:onProperty obo:BFO_0000051 ;
+                                                         owl:someValuesFrom obo:OBI_0002557
+                                                       ]
+                                                     ) ;
+                                  rdf:type owl:Class
+                                ] ;
+                obo:IAO_0000111 "age group inclusion criterion"@en ;
+                obo:IAO_0000112 "\"18-33 years old\""@en ;
+                obo:IAO_0000114 obo:IAO_0000123 ;
+                obo:IAO_0000115 "An inclusion criterion that defines and states an age bracket which, if met, makes an entity suitable for a given task or participation in a given process." ;
+                obo:IAO_0000117 "Mathias Brochhausen" ;
+                obo:IAO_0000233 "https://github.com/obi-ontology/obi/issues/839" ;
+                rdfs:label "age group inclusion criterion"@en .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0002556
+obo:OBI_0002556 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0001933 ;
+                obo:IAO_0000111 "minimum age value specification"@en ;
+                obo:IAO_0000114 obo:IAO_0000123 ;
+                obo:IAO_0000115 "A value specifcation that specifies the youngest age when specifying an age range."@en ;
+                obo:IAO_0000117 "Mathias Brochhausen"@en ;
+                rdfs:label "minimum age value specification"@en .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0002557
+obo:OBI_0002557 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0001933 ;
+                obo:IAO_0000111 "maximum age value specification"@en ;
+                obo:IAO_0000114 obo:IAO_0000123 ;
+                obo:IAO_0000115 "A value specifcation that specifies the oldest age when specifying an age range."@en ;
+                obo:IAO_0000117 "Mathias Brochhausen"@en ;
+                rdfs:label "maximum age value specification"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0002563
+obo:OBI_0002563 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0500027 ;
+                obo:IAO_0000111 "ethnicity inclusion criterion"@en ;
+                obo:IAO_0000112 "\"include only Hispanic individuals\""@en ;
+                obo:IAO_0000114 obo:IAO_0000123 ;
+                obo:IAO_0000115 "An inclusion criteria that defines and states one or more ethnicities which, if met, makes an entity suitable for a given task or participation in a given process."@en ;
+                obo:IAO_0000117 "Mathias Brochhausen"@en ;
+                rdfs:label "ethnicity inclusion criterion"@en .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0002564
+obo:OBI_0002564 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0600020 ;
+                obo:IAO_0000111 "histopathology assay" ;
+                obo:IAO_0000114 obo:IAO_0000123 ;
+                obo:IAO_0000115 "A histological assay that is intended to check for the presence or level of a specific disease." ;
+                obo:IAO_0000119 "OBI" ;
+                rdfs:label "histopathology assay" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0002566
+obo:OBI_0002566 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0200000 ;
+                obo:IAO_0000111 "file merge" ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A data transformation in which data contained in 2 or more files are merged into a single file." ;
+                obo:IAO_0000117 "Dan Berrios" ;
+                obo:IAO_0000119 "Dan Berrios" ;
+                rdfs:label "file merge" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0002587
+obo:OBI_0002587 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000011 ;
+                obo:IAO_0000111 "machine learning" ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A planned process in which statistical techniques are used to give computers the ability to learn about patterns in data, without being explicitly programmed.  Learning is defined in this case as progressively improving performance on a specific task." ;
+                obo:IAO_0000117 "Mark A. Miller" ;
+                obo:IAO_0000119 "https://en.wikipedia.org/wiki/Machine_learning" ;
+                dc:contributor "https://github.com/TrisSN" ;
+                rdfs:label "machine learning" .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0002588
+obo:OBI_0002588 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0002587 ;
+                obo:IAO_0000111 "supervised machine learning" ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A machine learning process using a function that maps an input to an output based on example input-output pairs. It infers a function from labeled training data consisting of a set of training examples." ;
+                obo:IAO_0000117 "Mark A. Miller" ;
+                obo:IAO_0000119 "https://en.wikipedia.org/wiki/Supervised_learning" ;
+                dc:contributor "https://github.com/TrisSN" ;
+                rdfs:label "supervised machine learning" .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0002589
+obo:OBI_0002589 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0002587 ;
+                obo:IAO_0000111 "unsupervised machine learning" ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A machine learning process that infers a function describing the structure of \"unlabeled\" data (i.e. data that has not been classified or categorized)." ;
+                obo:IAO_0000117 "Mark A. Miller" ;
+                obo:IAO_0000119 "https://en.wikipedia.org/wiki/Unsupervised_learning" ;
+                dc:contributor "https://github.com/TrisSN" ;
+                rdfs:label "unsupervised machine learning" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0002599
+obo:OBI_0002599 rdf:type owl:Class ;
+                owl:equivalentClass [ rdf:type owl:Restriction ;
+                                      owl:onProperty obo:OBI_0000312 ;
+                                      owl:someValuesFrom obo:OBI_0002600
+                                    ] ;
+                rdfs:subClassOf obo:OBI_0100051 ;
+                obo:IAO_0000111 "swab specimen" ;
+                obo:IAO_0000114 obo:IAO_0000122 ;
+                obo:IAO_0000115 "A specimen that is stored on a swab as the output of a collecting specimen with swab process." ;
+                obo:IAO_0000117 "Chris Stoeckert" ;
+                obo:IAO_0000119 "OBIB/OBI" ;
+                obo:IAO_0000233 "https://github.com/obi-ontology/obi/issues/910" ;
+                obo:IAO_0000234 "OBIB" ;
+                rdfs:label "swab specimen" .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0002600
+obo:OBI_0002600 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000659 ;
+                obo:IAO_0000111 "collecting specimen with swab" ;
+                obo:IAO_0000114 obo:IAO_0000122 ;
+                obo:IAO_0000115 "A specimen collection process that uses a swab as the collection device. A swab is an absorbent material (e.g. cotton) on a rod (e.g., wooden stick)." ;
+                obo:IAO_0000117 "Chris Stoeckert" ;
+                obo:IAO_0000119 "OBIB" ;
+                obo:IAO_0000233 "https://github.com/obi-ontology/obi/issues/910" ;
+                obo:IAO_0000234 "OBIB" ;
+                rdfs:label "collecting specimen with swab" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0002605
+obo:OBI_0002605 rdf:type owl:Class ;
+                owl:equivalentClass [ owl:intersectionOf ( [ owl:intersectionOf ( obo:OBI_0100051
+                                                                                  [ rdf:type owl:Restriction ;
+                                                                                    owl:onProperty obo:OBI_0000312 ;
+                                                                                    owl:someValuesFrom obo:OBI_0002600
+                                                                                  ]
+                                                                                ) ;
+                                                             rdf:type owl:Class
+                                                           ]
+                                                           [ owl:intersectionOf ( obo:OBI_0100051
+                                                                                  [ rdf:type owl:Restriction ;
+                                                                                    owl:onProperty obo:OBI_0000312 ;
+                                                                                    owl:someValuesFrom [ owl:intersectionOf ( obo:OBI_0000659
+                                                                                                                              [ rdf:type owl:Restriction ;
+                                                                                                                                owl:onProperty obo:OBI_0000293 ;
+                                                                                                                                owl:someValuesFrom obo:UBERON_0001567
+                                                                                                                              ]
+                                                                                                                            ) ;
+                                                                                                         rdf:type owl:Class
+                                                                                                       ]
+                                                                                  ]
+                                                                                ) ;
+                                                             rdf:type owl:Class
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf obo:OBI_0002599 ;
+                obo:IAO_0000111 "cheek swab specimen" ;
+                obo:IAO_0000114 obo:IAO_0000122 ;
+                obo:IAO_0000115 "A specimen that is collected with a swab from the cheek portion of the inside surface of a mouth." ;
+                obo:IAO_0000117 "Chris Stoeckert" ;
+                obo:IAO_0000119 "Chris Stoeckert, OBIB" ;
+                rdfs:label "cheek swab specimen" .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0002606
+obo:OBI_0002606 rdf:type owl:Class ;
+                owl:equivalentClass [ owl:intersectionOf ( [ owl:intersectionOf ( obo:OBI_0100051
+                                                                                  [ rdf:type owl:Restriction ;
+                                                                                    owl:onProperty obo:OBI_0000312 ;
+                                                                                    owl:someValuesFrom obo:OBI_0002600
+                                                                                  ]
+                                                                                ) ;
+                                                             rdf:type owl:Class
+                                                           ]
+                                                           [ owl:intersectionOf ( obo:OBI_0100051
+                                                                                  [ rdf:type owl:Restriction ;
+                                                                                    owl:onProperty obo:OBI_0000312 ;
+                                                                                    owl:someValuesFrom [ owl:intersectionOf ( obo:OBI_0000659
+                                                                                                                              [ rdf:type owl:Restriction ;
+                                                                                                                                owl:onProperty obo:OBI_0000293 ;
+                                                                                                                                owl:someValuesFrom obo:UBERON_0001728
+                                                                                                                              ]
+                                                                                                                            ) ;
+                                                                                                         rdf:type owl:Class
+                                                                                                       ]
+                                                                                  ]
+                                                                                ) ;
+                                                             rdf:type owl:Class
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf obo:OBI_0002599 ;
+                obo:IAO_0000111 "nasopharyngeal swab specimen" ;
+                obo:IAO_0000114 obo:IAO_0000122 ;
+                obo:IAO_0000115 "A specimen that is collected with a swab from the surface of a nasopharynx." ;
+                obo:IAO_0000117 "Chris Stoeckert" ;
+                obo:IAO_0000119 "Chris Stoeckert, OBIB" ;
+                rdfs:label "nasopharyngeal swab specimen" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0002615
+obo:OBI_0002615 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0500000 ;
+                obo:IAO_0000111 "disease specific study design" ;
+                obo:IAO_0000112 "A study of the symptoms experienced by patients who have been diagnosed with multiple sclerosis employs a disease specific study design." ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A study design for which material and information is collected from subjects that have already developed a particular disease." ;
+                obo:IAO_0000117 "MIABIS" ;
+                obo:IAO_0000119 "MIABIS contributors" ;
+                rdfs:label "disease specific study design" .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0002756
+obo:OBI_0002756 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0001930 ;
+                obo:IAO_0000111 "ordinal value specification"@en ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A categorical value specification in which the available categories were created with an explicit order." ;
+                obo:IAO_0000116 """https://en.wikipedia.org/wiki/Ordinal_data provides references for follow-up, but more than one OBI developer has objected to \"...whose levels have natural, ordered categories and the distances between those categories is not known...\"
+
+Separate from that, an OBI mechanism for asserting the order of ordinal values specification levels with OWL has not been determined yet.""" ;
+                obo:IAO_0000117 "Mark Andrew Miller, ORCID:0000-0001-9076-6066" ;
+                obo:IAO_0000119 "Bjoern Peters in https://github.com/obi-ontology/obi/issues/862" ;
+                obo:IAO_0000233 "https://github.com/obi-ontology/obi/issues/862" ;
+                rdfs:label "ordinal value specification"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0002814
+obo:OBI_0002814 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000968 ;
+                obo:IAO_0000111 "specimen collection device" ;
+                obo:IAO_0000114 obo:IAO_0000122 ;
+                obo:IAO_0000115 "A container used to collect a specimen." ;
+                obo:IAO_0000117 "https://orcid.org/0000-0002-8844-9165" ;
+                rdfs:label "specimen collection device" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0002821
+obo:OBI_0002821 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000968 ;
+                obo:IAO_0000111 "cotton swab" ;
+                obo:IAO_0000114 obo:IAO_0000122 ;
+                obo:IAO_0000115 "A device which is a cotton pad mounted on one or both ends of a stick." ;
+                obo:IAO_0000117 "https://orcid.org/0000-0002-8844-9165" ;
+                obo:IAO_0000118 "Q-tip" ,
+                                "swab-sampler" ;
+                obo:IAO_0000119 "https://en.wikipedia.org/wiki/Cotton_swab" ;
+                rdfs:label "cotton swab" .
+
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0002985
+obo:OBI_0002985 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000185 ,
+                                [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
+                                                         owl:onProperty obo:BFO_0000055 ;
+                                                         owl:someValuesFrom [ owl:intersectionOf ( obo:BFO_0000034
+                                                                                                   [ rdf:type owl:Restriction ;
+                                                                                                     owl:onProperty obo:RO_0000052 ;
+                                                                                                     owl:someValuesFrom obo:OBI_0000566
+                                                                                                   ]
+                                                                                                 ) ;
+                                                                              rdf:type owl:Class
+                                                                            ]
+                                                       ]
+                                                       [ rdf:type owl:Restriction ;
+                                                         owl:onProperty obo:OBI_0000293 ;
+                                                         owl:someValuesFrom obo:OBI_0000566
+                                                       ]
+                                                     ) ;
+                                  rdf:type owl:Class
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000055 ;
+                                  owl:someValuesFrom [ rdf:type owl:Restriction ;
+                                                       owl:onProperty obo:RO_0000059 ;
+                                                       owl:someValuesFrom obo:OBI_0003332
+                                                     ]
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000293 ;
+                                  owl:someValuesFrom [ rdf:type owl:Restriction ;
+                                                       owl:onProperty obo:RO_0000087 ;
+                                                       owl:someValuesFrom obo:OBI_0003330
+                                                     ]
+                                ] ;
+                obo:IAO_0000111 "magnetic resonance imaging assay" ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "An imaging assay in which nuclear magnetic resonance is used to produce information about the interior structure and composition of an input material entity." ;
+                obo:IAO_0000117 "Alexander D. Bartnik, ORCID:0000-0001-9676-7377" ,
+                                "Alexander D. Diehl, ORCID:0000-0001-9990-8331" ,
+                                "Lauren M. Wishnie, ORCID:0000-0002-7245-3450" ,
+                                "Lucas M. Serra, ORCID:0000-0002-2104-0568" ,
+                                "Mackenzie T. Smith, ORCID:0000-0002-9821-4132" ,
+                                "Rebecca Jackson" ,
+                                "William D. Duncan, ORCID:0000-0001-9625-1899" ;
+                obo:IAO_0000118 "MRI" ;
+                obo:IAO_0000119 "url:https://en.wikipedia.org/wiki/Magnetic_resonance_imaging" ;
+                obo:IAO_0000233 "https://github.com/obi-ontology/obi/issues/1290" ;
+                rdfs:label "magnetic resonance imaging assay" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0002986
+obo:OBI_0002986 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000185 ,
+                                [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
+                                                         owl:onProperty obo:BFO_0000055 ;
+                                                         owl:someValuesFrom [ owl:intersectionOf ( obo:BFO_0000034
+                                                                                                   [ rdf:type owl:Restriction ;
+                                                                                                     owl:onProperty obo:RO_0000052 ;
+                                                                                                     owl:someValuesFrom obo:OBI_0000982
+                                                                                                   ]
+                                                                                                 ) ;
+                                                                              rdf:type owl:Class
+                                                                            ]
+                                                       ]
+                                                       [ rdf:type owl:Restriction ;
+                                                         owl:onProperty obo:OBI_0000293 ;
+                                                         owl:someValuesFrom obo:OBI_0000982
+                                                       ]
+                                                     ) ;
+                                  rdf:type owl:Class
+                                ] ;
+                obo:IAO_0000111 "computed tomography imaging assay" ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "An imaging assay that uses a series of X-ray images to produce information about the interior structure and composition of an input material entity." ;
+                obo:IAO_0000117 "Rebecca Jackson" ;
+                obo:IAO_0000118 "CAT scan" ,
+                                "CT scan" ,
+                                "computed tomography scan" ;
+                obo:IAO_0000119 "url:https://www.mayoclinic.org/tests-procedures/ct-scan/about/pac-20393675" ;
+                obo:IAO_0000233 "https://github.com/obi-ontology/obi/issues/1290" ;
+                rdfs:label "computed tomography imaging assay" .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0002987
+obo:OBI_0002987 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000185 ,
+                                [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
+                                                         owl:onProperty obo:BFO_0000055 ;
+                                                         owl:someValuesFrom [ owl:intersectionOf ( obo:BFO_0000034
+                                                                                                   [ rdf:type owl:Restriction ;
+                                                                                                     owl:onProperty obo:RO_0000052 ;
+                                                                                                     owl:someValuesFrom obo:OBI_0000933
+                                                                                                   ]
+                                                                                                 ) ;
+                                                                              rdf:type owl:Class
+                                                                            ]
+                                                       ]
+                                                       [ rdf:type owl:Restriction ;
+                                                         owl:onProperty obo:OBI_0000293 ;
+                                                         owl:someValuesFrom obo:OBI_0000933
+                                                       ]
+                                                     ) ;
+                                  rdf:type owl:Class
+                                ] ;
+                obo:IAO_0000111 "positron emission tomography imaging assay" ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "An imaging assay in which positron-emitting radionuclides are used to visualize functional processes of an input material entity." ;
+                obo:IAO_0000117 "Rebecca Jackson" ;
+                obo:IAO_0000118 "PET scan" ,
+                                "positron emission tomography scan" ;
+                obo:IAO_0000119 "url:https://en.wikipedia.org/wiki/Positron_emission_tomography" ;
+                obo:IAO_0000233 "https://github.com/obi-ontology/obi/issues/1290" ;
+                rdfs:label "positron emission tomography imaging assay" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0002989
+obo:OBI_0002989 rdf:type owl:Class ;
+                owl:equivalentClass [ owl:intersectionOf ( [ rdf:type owl:Class ;
+                                                             owl:unionOf ( obo:NCBITaxon_9606
+                                                                           obo:OBI_0000245
+                                                                         )
+                                                           ]
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty obo:RO_0000087 ;
+                                                             owl:someValuesFrom obo:OBI_0000018
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf obo:BFO_0000040 ;
+                obo:IAO_0000111 "material supplier" ;
+                obo:IAO_0000114 obo:IAO_0000123 ;
+                obo:IAO_0000115 "A person or organization that provides material supplies to other people or organizations." ;
+                obo:IAO_0000117 "Rebecca Jackson" ;
+                obo:IAO_0000233 "https://github.com/obi-ontology/obi/issues/1289" ;
+                rdfs:label "material supplier" .
+
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0003040
+obo:OBI_0003040 rdf:type owl:Class ;
+                owl:equivalentClass [ owl:intersectionOf ( obo:OBI_0000070
+                                                           [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
+                                                                                    owl:onProperty obo:BFO_0000055 ;
+                                                                                    owl:someValuesFrom [ owl:intersectionOf ( obo:OBI_0000067
+                                                                                                                              [ rdf:type owl:Restriction ;
+                                                                                                                                owl:onProperty obo:RO_0000081 ;
+                                                                                                                                owl:someValuesFrom obo:OBI_0000655
+                                                                                                                              ]
+                                                                                                                            ) ;
+                                                                                                         rdf:type owl:Class
+                                                                                                       ]
+                                                                                  ]
+                                                                                  [ rdf:type owl:Restriction ;
+                                                                                    owl:onProperty obo:OBI_0000293 ;
+                                                                                    owl:someValuesFrom [ owl:intersectionOf ( obo:OBI_0000655
+                                                                                                                              [ rdf:type owl:Restriction ;
+                                                                                                                                owl:onProperty obo:RO_0000087 ;
+                                                                                                                                owl:someValuesFrom obo:OBI_0000067
+                                                                                                                              ]
+                                                                                                                            ) ;
+                                                                                                         rdf:type owl:Class
+                                                                                                       ]
+                                                                                  ]
+                                                                                ) ;
+                                                             rdf:type owl:Class
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf obo:OBI_0000070 ;
+                obo:IAO_0000111 "blood assay" ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "An assay that has a blood specimen as evaulant." ;
+                obo:IAO_0000117 "John Judkins" ;
+                obo:IAO_0000119 "VEuPathDB" ;
+                obo:IAO_0000233 "https://github.com/obi-ontology/obi/issues/1322" ;
+                rdfs:label "blood assay" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0003068
+obo:OBI_0003068 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000245 ;
+                obo:IAO_0000111 "clinical study center" ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "Organization that undertakes a clinical study at some point in time." ;
+                obo:IAO_0000117 "Chris Stoeckert" ,
+                                "Cristian Cocos" ,
+                                "Jie Zheng" ;
+                obo:IAO_0000119 "Penn Group" ;
+                rdfs:label "clinical study center" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0003070
+obo:OBI_0003070 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000272 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000051 ;
+                                  owl:someValuesFrom obo:OBI_0000684
+                                ] ;
+                obo:IAO_0000111 "specimen collection protocol" ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A protocol that specifies processes to fulfill a specimen collection objective." ;
+                obo:IAO_0000117 "John Judkins" ;
+                obo:IAO_0000119 "VEuPathDB" ;
+                rdfs:label "specimen collection protocol" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0003071
+obo:OBI_0003071 rdf:type owl:Class ;
+                owl:equivalentClass [ owl:intersectionOf ( obo:IAO_0000028
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty obo:IAO_0000219 ;
+                                                             owl:someValuesFrom [ rdf:type owl:Restriction ;
+                                                                                  owl:onProperty obo:RO_0000087 ;
+                                                                                  owl:someValuesFrom obo:OBI_0000097
+                                                                                ]
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf obo:IAO_0000028 ;
+                obo:IAO_0000111 "participant identifier" ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A symbol that denotes a participant under investigation." ;
+                obo:IAO_0000117 "John Judkins" ;
+                obo:IAO_0000119 "VEuPathDB" ;
+                rdfs:label "participant identifier" .
+
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0003073
+obo:OBI_0003073 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0003079 ;
+                obo:IAO_0000111 "organismal body temperature measurement datum" ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A temperature measurement datum that is about an organism." ;
+                obo:IAO_0000117 "Chris Stoeckert" ,
+                                "Jie Zheng" ;
+                obo:IAO_0000119 "Penn Group" ;
+                rdfs:label "organismal body temperature measurement datum" .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0003074
+obo:OBI_0003074 rdf:type owl:Class ;
+                rdfs:subClassOf obo:IAO_0000300 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:IAO_0000219 ;
+                                  owl:allValuesFrom obo:OBI_0100026
+                                ] ;
+                obo:IAO_0000111 "common name of organism" ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A textual entity refers to a taxon or organism that is based on the normal language of everyday life; this kind of name is often contrasted with the scientific name for the same organism, which is Latinized." ;
+                obo:IAO_0000117 "John Judkins" ;
+                obo:IAO_0000119 "https://en.wikipedia.org/wiki/Common_name" ;
+                rdfs:label "common name of organism" .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0003075
+obo:OBI_0003075 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0001169 ;
+                obo:IAO_0000111 "age since birth at time of enrollment" ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "An age since birth measurement datum at the time of subject enrollment." ;
+                obo:IAO_0000117 "Jie Zheng" ;
+                obo:IAO_0000119 "Penn Group" ;
+                rdfs:label "age since birth at time of enrollment" .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0003076
+obo:OBI_0003076 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0001169 ;
+                obo:IAO_0000111 "age since birth at time of visit" ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "An age since birth measurement datum at the time of a clinical visit." ;
+                obo:IAO_0000117 "Chris Stoeckert" ,
+                                "Grant Dorsey" ,
+                                "Jie Zheng" ,
+                                "Shon Cade" ;
+                obo:IAO_0000119 "Penn Group" ;
+                rdfs:label "age since birth at time of visit" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0003079
+obo:OBI_0003079 rdf:type owl:Class ;
+                rdfs:subClassOf obo:IAO_0000032 ;
+                obo:IAO_0000111 "temperature measurement datum" ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A scalar measurement datum that is the result of measuring temperature." ;
+                obo:IAO_0000117 "John Judkins" ;
+                obo:IAO_0000119 "VEuPathDB" ;
+                rdfs:label "temperature measurement datum" .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0003081
+obo:OBI_0003081 rdf:type owl:Class ;
+                rdfs:subClassOf obo:IAO_0000416 ;
+                obo:IAO_0000111 "extraction date" ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A time measurement datum that specifies when some material was extracted from an input material." ;
+                obo:IAO_0000117 "Chris Stoeckert, ORCID: 0000-0002-5714-991X" ;
+                obo:IAO_0000119 "FLU, VEuPathDB" ;
+                obo:IAO_0000233 "https://github.com/obi-ontology/obi/issues/1286" ;
+                rdfs:label "extraction date" .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0003250
+obo:OBI_0003250 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000245 ;
+                obo:IAO_0000111 "biomedical laboratory organization"@en ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "An organization that performs assays, processes specimens, analyses data and conducts planned processes relevant to the life sciences." ;
+                obo:IAO_0000117 "Christian Stoeckert ORCID:0000-0002-5714-991X" ,
+                                "Jie Zheng ORCID:0000-0002-2999-0103" ;
+                obo:IAO_0000118 "laboratory" ;
+                obo:IAO_0000119 "OBIB" ,
+                                "eagle-i resource ontology ERO_0000001" ;
+                obo:IAO_0000233 "https://github.com/obi-ontology/obi/issues/1436" ;
+                obo:IAO_0000234 "OBIB" ;
+                rdfs:label "biomedical laboratory organization"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0003291
+obo:OBI_0003291 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0500000 ;
+                obo:IAO_0000111 "in silico design" ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A study design that is executed primarily on a computer." ;
+                obo:IAO_0000117 "Hector Guzman-Orozco" ;
+                obo:IAO_0000119 "https://en.wikipedia.org/wiki/In_silico" ;
+                obo:IAO_0000233 "https://github.com/obi-ontology/obi/issues/1430" ;
+                obo:IAO_0000234 "CMI-PB" ;
+                rdfs:label "in silico design" .
+
+
+### NOT SURE I WANT THIS - WHY NOT HAVE A GENERIC DATASET AND SPECIFY THE ACTIVTY THAT GENERATED IT?
+###  http://purl.obolibrary.org/obo/OBI_0003327
+obo:OBI_0003327 rdf:type owl:Class ;
+                rdfs:subClassOf obo:IAO_0000100 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:IAO_0000136 ;
+                                  owl:someValuesFrom obo:BFO_0000001
+                                ] ;
+                obo:IAO_0000111 "image data set" ;
+                obo:IAO_0000112 "The output produced by a digital imaging technique, such as microscopy, MRI, or CT." ;
+                obo:IAO_0000114 obo:IAO_0000123 ;
+                obo:IAO_0000115 "A data set that is comprised of multidimensional structured measurements and metadata required for a morphological representation of an entity. An image data set can be the source from which an image (such as a 2D image using pixels or a 3D image using voxels) is produced." ;
+                obo:IAO_0000117 "https://orcid.org/0000-0001-9625-1899 \"William D. Duncan\"" ,
+                                "https://orcid.org/0000-0001-9676-7377 \"Alexander D. Bartnik\"" ,
+                                "https://orcid.org/0000-0001-9990-8331 \"Alexander D. Diehl\"" ,
+                                "https://orcid.org/0000-0002-2104-0568 \"Lucas M. Serra\"" ,
+                                "https://orcid.org/0000-0002-7245-3450 \"Lauren M. Wishnie\"" ,
+                                "https://orcid.org/0000-0002-9821-4132 \"Mackenzie T. Smith\"" ;
+                obo:IAO_0000233 "https://github.com/obi-ontology/obi/issues/1481" ;
+                rdfs:label "image data set" .
+
+
+### NOT SURE I WANT THIS - NO REASON TO SPECIFY ASSAY THIS WAY
+###  http://purl.obolibrary.org/obo/OBI_0003328
+obo:OBI_0003328 rdf:type owl:Class ;
+                owl:equivalentClass [ owl:intersectionOf ( obo:OBI_0003327
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty obo:IAO_0000136 ;
+                                                             owl:someValuesFrom obo:OBI_0003329
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf obo:OBI_0003327 ;
+                obo:IAO_0000111 "magnetic resonance image data set" ;
+                obo:IAO_0000112 "The DICOM file produced by an MRI machine when a multiple sclerosis patient undergoes a brain scan." ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "An image data set whose information content originates from some MR imaging assay and is about some MRI participant." ;
+                obo:IAO_0000117 "https://orcid.org/0000-0001-9625-1899 \"William D. Duncan\"" ,
+                                "https://orcid.org/0000-0001-9676-7377 \"Alexander D. Bartnik\"" ,
+                                "https://orcid.org/0000-0001-9990-8331 \"Alexander D. Diehl\"" ,
+                                "https://orcid.org/0000-0002-2104-0568 \"Lucas M. Serra\"" ,
+                                "https://orcid.org/0000-0002-7245-3450 \"Lauren M. Wishnie\"" ,
+                                "https://orcid.org/0000-0002-9821-4132 \"Mackenzie T. Smith\"" ;
+                obo:IAO_0000119 "MRI at a Glance, ISBN 10: 1119053552" ;
+                obo:IAO_0000233 "https://github.com/obi-ontology/obi/issues/1481" ;
+                rdfs:label "magnetic resonance image data set" .
+
+
+
+### NOT SURE I WANT THIS - NO NEED TO SPECIFY THE TYPE OF ASSAY THIS WAY
+###  http://purl.obolibrary.org/obo/OBI_0003329
+obo:OBI_0003329 rdf:type owl:Class ;
+                owl:equivalentClass [ owl:intersectionOf ( obo:BFO_0000040
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty obo:RO_0000053 ;
+                                                             owl:someValuesFrom obo:OBI_0003330
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf obo:BFO_0000040 ;
+                obo:IAO_0000111 "magnetic resonance imaging participant"@en ;
+                obo:IAO_0000114 obo:IAO_0000123 ;
+                obo:IAO_0000115 "The subject being scanned in an MRI study, and bearor of data derived from that study." ;
+                obo:IAO_0000117 "https://orcid.org/0000-0001-9625-1899 \"William D. Duncan\"" ,
+                                "https://orcid.org/0000-0001-9676-7377 \"Alexander D. Bartnik\"" ,
+                                "https://orcid.org/0000-0001-9990-8331 \"Alexander D. Diehl\"" ,
+                                "https://orcid.org/0000-0002-7245-3450 \"Lauren M. Wishnie\"" ,
+                                "https://orcid.org/0000-0002-9821-4132 \"Mackenzie T. Smith\"" ;
+                rdfs:label "magnetic resonance imaging participant"@en .
+
+
+### SAME HERE - WHY NOT HAVE AN GENERIC EVALUANT AND SPECIFY THE ACTIVITY THAT CREATED THE DATASET?
+###  http://purl.obolibrary.org/obo/OBI_0003330
+obo:OBI_0003330 rdf:type owl:Class ;
+                owl:equivalentClass [ owl:intersectionOf ( obo:OBI_0000067
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty obo:BFO_0000054 ;
+                                                             owl:someValuesFrom obo:OBI_0002985
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf obo:OBI_0000067 ;
+                obo:IAO_0000111 "magnetic resonance imaging evaluant role"@en ;
+                obo:IAO_0000114 obo:IAO_0000123 ;
+                obo:IAO_0000115 "An evaluant role that inheres in a material entity that is realized in a MR imaging assay in which MR imaging data is generated about the bearer of the evaluant role." ;
+                obo:IAO_0000117 "https://orcid.org/0000-0001-9625-1899 \"William D. Duncan\"" ,
+                                "https://orcid.org/0000-0001-9676-7377 \"Alexander D. Bartnik\"" ,
+                                "https://orcid.org/0000-0001-9990-8331 \"Alexander D. Diehl\"" ,
+                                "https://orcid.org/0000-0002-2104-0568 \"Lucas M. Serra\"" ,
+                                "https://orcid.org/0000-0002-7245-3450 \"Lauren M. Wishnie\"" ,
+                                "https://orcid.org/0000-0002-9821-4132 \"Mackenzie T. Smith\"" ;
+                rdfs:label "magnetic resonance imaging evaluant role"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0003331
+obo:OBI_0003331 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0003327 ;
+                obo:IAO_0000111 "raw image data set" ;
+                obo:IAO_0000112 "The untransformed (\"k-space\") data produced by an MRI machine, prior to mathematical transformation into a form that corresponds to the anatomical structure of the brain." ;
+                obo:IAO_0000114 obo:IAO_0000123 ;
+                obo:IAO_0000115 "An image data set that encodes measurement values produced by some instrument before undergoing a data transformation." ;
+                obo:IAO_0000117 "https://orcid.org/0000-0001-9625-1899 \"William D. Duncan\"" ,
+                                "https://orcid.org/0000-0001-9676-7377 \"Alexander D. Bartnik\"" ,
+                                "https://orcid.org/0000-0001-9990-8331 \"Alexander D. Diehl\"" ,
+                                "https://orcid.org/0000-0002-1604-3078 \"Alan Ruttenberg\"" ,
+                                "https://orcid.org/0000-0002-2104-0568 \"Lucas M. Serra\"" ,
+                                "https://orcid.org/0000-0002-7245-3450 \"Lauren M. Wishnie\"" ,
+                                "https://orcid.org/0000-0002-9821-4132 \"Mackenzie T. Smith\"" ;
+                obo:IAO_0000233 "https://github.com/obi-ontology/obi/issues/1481" ;
+                rdfs:label "raw image data set" .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0003332
+obo:OBI_0003332 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000272 ;
+                obo:IAO_0000111 "magnetic resonance pulse sequence protocol"@en ;
+                obo:IAO_0000114 obo:IAO_0000123 ;
+                obo:IAO_0000115 "The NMR/MRI machine protocol about the radiofrequency pulse sequence." ;
+                obo:IAO_0000117 "https://orcid.org/0000-0001-9676-7377 \"Alexander D. Bartnik\"" ,
+                                "https://orcid.org/0000-0001-9990-8331 \"Alexander D. Diehl\"" ,
+                                "https://orcid.org/0000-0002-2104-0568 \"Lucas M. Serra\"" ,
+                                "https://orcid.org/0000-0002-9821-4132 \"Mackenzie T. Smith\"" ;
+                rdfs:label "magnetic resonance pulse sequence protocol"@en .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0003355
+obo:OBI_0003355 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0200000 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000293 ;
+                                  owl:someValuesFrom obo:OBI_0003327
+                                ] ;
+                obo:IAO_0000111 "image data set analysis" ;
+                obo:IAO_0000114 obo:IAO_0000123 ;
+                obo:IAO_0000115 "The process of deriving a data item from an image data set using computer algorithms. The produced data item can be an image data set, data measurement, or any other data item." ;
+                obo:IAO_0000117 "https://orcid.org/0000-0001-9625-1899 \"William D. Duncan\"" ,
+                                "https://orcid.org/0000-0001-9676-7377 \"Alexander D. Bartnik\"" ,
+                                "https://orcid.org/0000-0001-9990-8331 \"Alexander D. Diehl\"" ,
+                                "https://orcid.org/0000-0002-2104-0568 \"Lucas M. Serra\"" ,
+                                "https://orcid.org/0000-0002-7245-3450 \"Lauren M. Wishnie\"" ,
+                                "https://orcid.org/0000-0002-9821-4132 \"Mackenzie T. Smith\"" ;
+                obo:IAO_0000233 "https://github.com/obi-ontology/obi/issues/1481" ;
+                rdfs:label "image data set analysis" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0003366
+obo:OBI_0003366 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000338 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000299 ;
+                                  owl:someValuesFrom obo:OBI_0003367
+                                ] ;
+                obo:IAO_0000111 "organism diagnostic process"@en ;
+                obo:IAO_0000114 obo:IAO_0000123 ;
+                obo:IAO_0000115 "A drawing a conclusion based on data that involves the interpretation of data about a given organism (human, animal, or plant) and the assertion to the effect that the organism has a disease, disorder, or syndrome of a certain type, or none of these as output." ;
+                obo:IAO_0000117 "Jie Zheng" ;
+                obo:IAO_0000233 "https://github.com/obi-ontology/obi/issues/1505" ;
+                rdfs:label "organism diagnostic process"@en .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0003367
+obo:OBI_0003367 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0001909 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000312 ;
+                                  owl:someValuesFrom obo:OBI_0003366
+                                ] ;
+                obo:IAO_0000111 "diagnosis of an organism"@en ;
+                obo:IAO_0000114 obo:IAO_0000123 ;
+                obo:IAO_0000115 "A conclusion based on data about that an organism has a disease, disorder, or syndrome of a certain type, or none of these." ;
+                obo:IAO_0000117 "Jie Zheng" ;
+                obo:IAO_0000233 "https://github.com/obi-ontology/obi/issues/1505" ;
+                rdfs:label "diagnosis of an organism"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0003368
+obo:OBI_0003368 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000070 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000050 ;
+                                  owl:someValuesFrom obo:OBI_0000070
+                                ] ;
+                obo:IAO_0000111 "detection technique" ;
+                obo:IAO_0000112 "Using a radioactivity detection assay as part of a tritiated thymidine incorporation assay to determine the degree to which cells are replicating by detecting radioactivity of tritiated thymidine, where radioactivity of tritiated thymidine in a cell is a proxy for cells that were actively replicating." ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "An assay (A) that is part of another assay (B), where the target entities of A and B are disjoint, and the target entity of A is a proxy for the target of assay B." ;
+                obo:IAO_0000117 "Bjoern Peters" ,
+                                "Hector Guzman-Orozco" ;
+                obo:IAO_0000119 "OBI" ;
+                obo:IAO_0000233 "https://github.com/obi-ontology/obi/issues/1488" ;
+                rdfs:label "detection technique" .
+
+
+### COULD ALSO GENERALIZE THIS TO BIOMARKER KIT THAT IS CODE NOT FLUID BASED
+###  http://purl.obolibrary.org/obo/OBI_0003369
+obo:OBI_0003369 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000968 ;
+                obo:IAO_0000111 "assay kit" ;
+                obo:IAO_0000112 "Glutathione S-Transferase (GST) Assay Kit: https://www.sigmaaldrich.com/deepweb/assets/sigmaaldrich/product/documents/101/301/cs0410bul.pdf" ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A device that consists of reagents and devices that enable the performance of a specific type of assay, which could, in addition, require specific instruments not included in the kit." ;
+                obo:IAO_0000117 "John Judkins" ;
+                obo:IAO_0000119 "OBI, VEuPathDB" ;
+                obo:IAO_0000233 "https://github.com/obi-ontology/obi/issues/1456" ;
+                obo:IAO_0000234 "VEuPathDB" ;
+                rdfs:label "assay kit" .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0003374
+obo:OBI_0003374 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0003366 ;
+                obo:IAO_0000111 "remote patient assessment"@en ;
+                obo:IAO_0000112 "A telephone or video remote patient assessment conducted between a physician and patient."@en ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "An organism diagnostic process which involves a remote assessment of a patient by a clinician."@en ;
+                obo:IAO_0000117 <https://orcid.org/0000-0002-0548-891X> ;
+                obo:IAO_0000118 "telehealth patient assessment"@en ;
+                obo:IAO_0000119 <https://doi.org/10.1016/j.jpainsymman.2020.03.019> ;
+                dc:date "2022-05-02T14:15:39Z"^^xsd:dateTime ;
+                rdfs:label "remote patient assessment"@en .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0003414
+obo:OBI_0003414 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0600007 ;
+                obo:IAO_0000111 "administering substance in vivo to reduce or prevent disease" ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "An administration of substance in vivo with the intention to reduce the symptoms of or prevent development of a disease in the organism." ;
+                obo:IAO_0000117 "IEDB" ;
+                obo:IAO_0000119 "IEDB" ;
+                rdfs:label "administering substance in vivo to reduce or prevent disease" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0003456
+obo:OBI_0003456 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0600007 ;
+                obo:IAO_0000111 "in vivo challenge" ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "The administration of a challenge to a live host." ;
+                obo:IAO_0000117 "Hector Guzman-Orozco" ;
+                obo:IAO_0000119 "IEDB" ;
+                rdfs:label "in vivo challenge" .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0003501
+obo:OBI_0003501 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0002441 ;
+                obo:IAO_0000111 "functional assessment of individual" ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A physical examination of an individual's ability to perform functional activities." ;
+                obo:IAO_0000117 "Daniel Olson, ORCID: 0000-0002-8134-1207" ;
+                obo:IAO_0000119 "Critical Path Institute" ;
+                obo:IAO_0000233 "https://github.com/obi-ontology/obi/issues/1637" ;
+                rdfs:label "functional assessment of individual" .
+
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0003510
+obo:OBI_0003510 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0003501 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000299 ;
+                                  owl:someValuesFrom [ rdf:type owl:Restriction ;
+                                                       owl:onProperty obo:IAO_0000136 ;
+                                                       owl:someValuesFrom obo:UBERON_0002389
+                                                     ]
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000299 ;
+                                  owl:someValuesFrom [ rdf:type owl:Restriction ;
+                                                       owl:onProperty obo:IAO_0000221 ;
+                                                       owl:someValuesFrom obo:OBA_2060181
+                                                     ]
+                                ] ;
+                obo:IAO_0000111 "finger taps assessment" ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A functional assessment of an individual's ability to touch their finger-tip to thumb as many times as possible during a specified duration of time." ;
+                obo:IAO_0000117 "Daniel Olson, ORCID: 0000-0002-8134-1207" ;
+                obo:IAO_0000119 "Critical Path Institute" ;
+                obo:IAO_0000233 "https://github.com/obi-ontology/obi/issues/1637" ;
+                rdfs:label "finger taps assessment" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0003527
+obo:OBI_0003527 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0003518 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000299 ;
+                                  owl:someValuesFrom [ rdf:type owl:Restriction ;
+                                                       owl:onProperty obo:IAO_0000221 ;
+                                                       owl:someValuesFrom obo:OBA_2060184
+                                                     ]
+                                ] ;
+                obo:IAO_0000111 "gait assessment" ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A limits of stability assessment designed to assess an individual's manner or pattern of walking." ;
+                obo:IAO_0000117 "Daniel Olson, ORCID: 0000-0002-8134-1207" ;
+                obo:IAO_0000119 "Critical Path Institute" ;
+                obo:IAO_0000233 "https://github.com/obi-ontology/obi/issues/1637" ;
+                rdfs:label "gait assessment" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0003536
+obo:OBI_0003536 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0002441 ;
+                obo:IAO_0000111 "observational assessment of individual" ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A physical examination of an individual through visual assesment." ;
+                obo:IAO_0000117 "Daniel Olson, ORCID: 0000-0002-8134-1207" ;
+                obo:IAO_0000119 "Critical Path Institute" ;
+                obo:IAO_0000233 "https://github.com/obi-ontology/obi/issues/1637" ;
+                rdfs:label "observational assessment of individual" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0100016
+obo:OBI_0100016 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000953 ,
+                                [ owl:intersectionOf ( obo:BFO_0000040
+                                                       [ rdf:type owl:Restriction ;
+                                                         owl:onProperty obo:RO_0000087 ;
+                                                         owl:someValuesFrom obo:OBI_0000112
+                                                       ]
+                                                     ) ;
+                                  rdf:type owl:Class
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000312 ;
+                                  owl:someValuesFrom [ owl:intersectionOf ( obo:OBI_0600014
+                                                                            [ rdf:type owl:Restriction ;
+                                                                              owl:onProperty obo:OBI_0000293 ;
+                                                                              owl:someValuesFrom obo:OBI_0000655
+                                                                            ]
+                                                                          ) ;
+                                                       rdf:type owl:Class
+                                                     ]
+                                ] ;
+                obo:IAO_0000111 "blood plasma specimen"@en ;
+                obo:IAO_0000112 "PMID: 18217225.Sex Transm Dis. 2008 Jan;35(1):55-60. Review.Human immunodeficiency virus viral load in blood plasma and semen: review and implications of empirical findings."@en ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "a material entity which corresponds to the liquid component of blood, in which the blood cells are suspended."@en ;
+                obo:IAO_0000116 "03/21/2010: BP, blood plasma is defined as the output of certain separation processes, so this is in the domain of OBI, not FMA."@en ;
+                obo:IAO_0000117 "PERSON: Maura Gasparetto"@en ,
+                                "PERSON: Melanie Courtot"@en ,
+                                "PERSON: Philippe Rocca-Serra" ;
+                obo:IAO_0000118 "plasma"@en ;
+                obo:IAO_0000119 "WEB: http://en.wikipedia.org/wiki/Blood_plasma"@en ;
+                rdfs:label "blood plasma specimen"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0100017
+obo:OBI_0100017 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000953 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000312 ;
+                                  owl:someValuesFrom [ owl:intersectionOf ( [ rdf:type owl:Class ;
+                                                                              owl:unionOf ( obo:OBI_0302885
+                                                                                            obo:OBI_0302886
+                                                                                            obo:OBI_0600052
+                                                                                          )
+                                                                            ]
+                                                                            [ rdf:type owl:Restriction ;
+                                                                              owl:onProperty obo:OBI_0000293 ;
+                                                                              owl:someValuesFrom obo:OBI_0000655
+                                                                            ]
+                                                                          ) ;
+                                                       rdf:type owl:Class
+                                                     ]
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:RO_0000087 ;
+                                  owl:someValuesFrom obo:OBI_0000112
+                                ] ;
+                obo:IAO_0000111 "blood serum specimen"@en ;
+                obo:IAO_0000112 "PMID: 18229666.Adv Med Sci. 2007;52 Suppl 1:204-6.Antioxidant activity of blood serum and saliva in patients with periodontal disease treated due to epilepsy."@en ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A material entity which derives from blood and corresponds to blood plasma without fibrinogen or the other clotting factors."@en ;
+                obo:IAO_0000117 "PERSON: Maura Gasparetto"@en ,
+                                "PERSON: Melanie Courtot"@en ,
+                                "PERSON: Philippe Rocca-Serra" ;
+                obo:IAO_0000119 "WEB: http://en.wikipedia.org/wiki/Blood_plasma"@en ;
+                rdfs:label "blood serum specimen"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0100026
+obo:OBI_0100026 rdf:type owl:Class ;
+                owl:equivalentClass [ rdf:type owl:Class ;
+                                      owl:unionOf ( obo:NCBITaxon_10239
+                                                    obo:NCBITaxon_2
+                                                    obo:NCBITaxon_2157
+                                                    obo:NCBITaxon_2759
+                                                  )
+                                    ] ;
+                rdfs:subClassOf obo:BFO_0000040 ;
+                obo:IAO_0000111 "organism"@en ;
+                obo:IAO_0000112 "animal"@en ,
+                                "fungus"@en ,
+                                "plant"@en ,
+                                "virus"@en ;
+                obo:IAO_0000114 obo:IAO_0000122 ;
+                obo:IAO_0000115 "A material entity that is an individual living system, such as animal, plant, bacteria or virus, that is capable of replicating or reproducing, growth and maintenance in the right environment. An organism may be unicellular or made up, like humans, of many billions of cells divided into specialized tissues and organs."@en ;
+                obo:IAO_0000116 "10/21/09: This is a placeholder term, that should ideally be imported from the NCBI taxonomy, but the high level hierarchy there does not suit our needs (includes plasmids and 'other organisms')" ,
+                                """13-02-2009:
+OBI doesn't take position as to  when an organism starts or ends being an organism - e.g. sperm, foetus.
+This issue is outside the scope of OBI.""" ;
+                obo:IAO_0000117 "GROUP: OBI Biomaterial Branch" ;
+                obo:IAO_0000119 "WEB: http://en.wikipedia.org/wiki/Organism"@en ;
+                rdfs:label "organism"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0100051
+obo:OBI_0100051 rdf:type owl:Class ;
+                owl:equivalentClass [ owl:intersectionOf ( obo:BFO_0000040
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty obo:RO_0000087 ;
+                                                             owl:someValuesFrom obo:OBI_0000112
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf obo:BFO_0000040 ;
+                obo:IAO_0000111 "specimen"@en ;
+                obo:IAO_0000112 "Biobanking of blood taken and stored in a freezer for potential future investigations stores specimen." ;
+                obo:IAO_0000114 obo:IAO_0000122 ;
+                obo:IAO_0000115 "A material entity that has the specimen role."@en ;
+                obo:IAO_0000116 "Note: definition is in specimen creation objective which is defined as an objective to obtain and store a material entity for potential use as an input during an investigation." ;
+                obo:IAO_0000117 "PERSON: James Malone" ,
+                                "PERSON: Philippe Rocca-Serra" ;
+                obo:IAO_0000119 "GROUP: OBI Biomaterial Branch"@en ;
+                obo:IAO_0000233 <https://github.com/obi-ontology/obi/issues/1013> ;
+                rdfs:label "specimen"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0100066
+obo:OBI_0100066 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000047 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000312 ;
+                                  owl:someValuesFrom [ rdf:type owl:Class ;
+                                                       owl:unionOf ( obo:OBI_0000341
+                                                                     obo:OBI_0600005
+                                                                   )
+                                                     ]
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:RO_0001000 ;
+                                  owl:someValuesFrom obo:UBERON_0000465
+                                ] ;
+                obo:IAO_0000111 "organ section"@en ;
+                obo:IAO_0000112 """A liver slice used in a perfusion experiment.
+Thyroidectomy during laryngectomy for advanced laryngeal carcinoma--whole organ section study with long-term functional evaluation. Clin Otolaryngol Allied Sci. 1995 Apr;20(2):145-9. PMID: 7634521"""@en ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "A processed material which derives from an organ and results from a process of dissection or histological sample preparation a portion(formerly an organ section is portion of an organ removed from the context of the organ)"@en ;
+                obo:IAO_0000117 "PERSON: Helen Parkinson"@en ,
+                                "PERSON: Philippe Rocca-Serra" ;
+                obo:IAO_0000119 "GROUP: CEBS"@en ,
+                                "GROUP: OBI Biomaterial Branch" ;
+                rdfs:label "organ section"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0200000
+obo:OBI_0200000 rdf:type owl:Class ;
+                owl:equivalentClass [ rdf:type owl:Restriction ;
+                                      owl:onProperty obo:OBI_0000417 ;
+                                      owl:someValuesFrom obo:OBI_0200166
+                                    ] ;
+                rdfs:subClassOf obo:OBI_0000011 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000055 ;
+                                  owl:someValuesFrom [ rdf:type owl:Restriction ;
+                                                       owl:onProperty obo:RO_0000059 ;
+                                                       owl:someValuesFrom [ owl:intersectionOf ( obo:IAO_0000064
+                                                                                                 [ rdf:type owl:Restriction ;
+                                                                                                   owl:onProperty obo:BFO_0000051 ;
+                                                                                                   owl:someValuesFrom obo:IAO_0000005
+                                                                                                 ]
+                                                                                               ) ;
+                                                                            rdf:type owl:Class
+                                                                          ]
+                                                     ]
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000293 ;
+                                  owl:allValuesFrom obo:IAO_0000027
+                                ] ;
+                owl:disjointWith obo:OBI_0600013 ;
+                obo:IAO_0000111 "data transformation"@en ;
+                obo:IAO_0000112 "The application of a clustering protocol to microarray data or the application of a statistical testing method on a primary data set to determine a p-value." ;
+                obo:IAO_0000114 obo:IAO_0000122 ;
+                obo:IAO_0000115 "A planned process that produces output data from input data."@en ;
+                obo:IAO_0000117 "Elisabetta Manduchi"@en ,
+                                "Helen Parkinson"@en ,
+                                "James Malone"@en ,
+                                "Melanie Courtot"@en ,
+                                "Philippe Rocca-Serra" ,
+                                "Richard Scheuermann"@en ,
+                                "Ryan Brinkman"@en ,
+                                "Tina Hernandez-Boussard"@en ;
+                obo:IAO_0000118 "data analysis"@en ,
+                                "data processing"@en ;
+                obo:IAO_0000119 "Branch editors"@en ;
+                obo:IAO_0000412 <http://purl.obolibrary.org/obo/obi.owl> ;
+                rdfs:label "data transformation"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0200005
+obo:OBI_0200005 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0200166 ;
+                obo:IAO_0000111 "feature extraction objective"@en ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "A feature extraction objective is a data transformation objective where the aim of the data transformation is to generate quantified values from a scanned image."@en ;
+                obo:IAO_0000117 "Elisabetta Manduchi" ,
+                                "James Malone"@en ;
+                obo:IAO_0000119 "TERM: http://mged.sourceforge.net/ontologies/MGEDOntology.owl#feature_extraction"@en ;
+                rdfs:label "feature extraction objective"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0200029
+obo:OBI_0200029 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0200169 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000417 ;
+                                  owl:someValuesFrom obo:OBI_0200167
+                                ] ;
+                obo:IAO_0000111 "mean centering"@en ;
+                obo:IAO_0000112 "This can be used as a normalization method in expression microarray assays. For example, given a two-channel microarray assay, the log ratios of the two channels (M values) can be mean-centered."@en ;
+                obo:IAO_0000114 obo:IAO_0000122 ;
+                obo:IAO_0000115 "A mean centering is a data transformation that takes as input an n-dimensional (real) vector, performs a mean calculation on its components, and subtracts the resulting mean from each component of the input."@en ;
+                obo:IAO_0000117 "Elisabetta Manduchi"@en ,
+                                "Philippe Rocca-Serra" ;
+                obo:IAO_0000118 "mean centring"@en ;
+                obo:IAO_0000119 "PERSON: Elisabetta Manduchi"@en ;
+                rdfs:label "mean centering"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0200030
+obo:OBI_0200030 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0200169 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000417 ;
+                                  owl:someValuesFrom obo:OBI_0200167
+                                ] ;
+                obo:IAO_0000111 "median centering"@en ;
+                obo:IAO_0000112 "This can be used as a normalization method in expression microarray assays. For example, given a two-channel microarray assay, the log ratios of the two channels (M values) can be median-centered."@en ;
+                obo:IAO_0000114 obo:IAO_0000122 ;
+                obo:IAO_0000115 "A median centering is a data transformation that takes as input an n-dimensional (real) vector, performs a median calculation on its components, and subtracts the resulting median from each component of the input."@en ;
+                obo:IAO_0000117 "Elisabetta Manduchi"@en ,
+                                "Philippe Rocca-Serra" ;
+                obo:IAO_0000118 "median centring"@en ;
+                obo:IAO_0000119 "PERSON: Elisabetta Manduchi"@en ;
+                rdfs:label "median centering"@en .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0200033
+obo:OBI_0200033 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000792 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000417 ;
+                                  owl:someValuesFrom obo:OBI_0200188
+                                ] ;
+                obo:IAO_0000111 "leave one out cross validation method"@en ;
+                obo:IAO_0000112 "The authors conducted  leave-one-out cross validation to estimate the strength and accuracy of the differentially expressed filtered genes. http://bioinformatics.oxfordjournals.org/cgi/content/abstract/19/3/368" ;
+                obo:IAO_0000114 obo:IAO_0000123 ;
+                obo:IAO_0000115 "is a data transformation :  leave-one-out cross-validation (LOOCV) involves using a single observation from the original sample as the validation data, and the remaining observations as the training data. This is repeated such that each observation in the sample is used once as the validation data" ;
+                obo:IAO_0000116 "2009-11-10. Tracker: https://sourceforge.net/tracker/?func=detail&aid=2893049&group_id=177891&atid=886178" ;
+                obo:IAO_0000117 "Person:Helen Parkinson" ;
+                rdfs:label "leave one out cross validation method"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0200034
+obo:OBI_0200034 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000792 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000417 ;
+                                  owl:someValuesFrom obo:OBI_0200188
+                                ] ;
+                obo:IAO_0000111 "jackknifing method" ;
+                obo:IAO_0000112 "simple weighting procedure is suggested for combining information over alleles and loci, and sample variances may be estimated by a jackknife procedure" ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "Jacknifing is a re-sampling data transformation process used to estimate the precision of sampling statistics and is a resampling method" ;
+                obo:IAO_0000117 "Helen Parkinson" ;
+                obo:IAO_0000118 "jackknifing"@en ;
+                obo:IAO_0000119 "http://en.wikipedia.org/wiki/Resampling_%28statistics%29" ;
+                rdfs:label "jackknifing method"@en .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0200035
+obo:OBI_0200035 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000792 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000417 ;
+                                  owl:someValuesFrom obo:OBI_0200188
+                                ] ;
+                obo:IAO_0000111 "boostrapping"@en ;
+                obo:IAO_0000112 "Although widely accepted that high throughput biological data are typically highly noisy, the effects that this uncertainty has upon the conclusions we draw from these data are often overlooked. However, in order to assign any degree of confidence to our conclusions, we must quantify these effects. Bootstrap resampling is one method by which this may be achieved." ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "Bootstrapping is a statistical method for estimating the sampling distribution of a statistic by sampling with replacement from the original data, most often with the purpose of deriving robust estimates of standard errors and confidence intervals of a population parameter like a mean, median, proportion, odds ratio, correlation coefficient or regression coefficient"@en ;
+                obo:IAO_0000117 "Helen Parkinson" ;
+                obo:IAO_0000119 "Bootstrapping is a data transformation process which estimates the precision of sampling statistics by drawing randomly with replacement from a set of data points" ;
+                rdfs:label "boostrapping"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0200036
+obo:OBI_0200036 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0200163 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000293 ;
+                                  owl:someValuesFrom obo:OBI_0000175
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000299 ;
+                                  owl:someValuesFrom obo:OBI_0000662
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000299 ;
+                                  owl:someValuesFrom obo:OBI_0001442
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000417 ;
+                                  owl:someValuesFrom obo:OBI_0000791
+                                ] ;
+                obo:IAO_0000111 "Benjamini and Hochberg false discovery rate correction method"@en ;
+                obo:IAO_0000112 "Statistical significance of the 8 most represented biological processes (GO level 4) among E7 6 month upregulated genes following analysis with DAVID software; Benjamini-Hochberg FDR (false discovery rate)" ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A data transformation process in which the Benjamini and Hochberg method sequential p-value procedure  is applied with the aim of correcting false discovery rate" ;
+                obo:IAO_0000116 """2011-03-31: [PRS]. 
+specified input and output of dt which were missing"""@en ;
+                obo:IAO_0000117 "Helen Parkinson" ,
+                                "Philippe Rocca-Serra"@en ;
+                obo:IAO_0000119 "Helen Parkinson" ;
+                rdfs:label "Benjamini and Hochberg false discovery rate correction method"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0200041
+obo:OBI_0200041 rdf:type owl:Class ;
+                rdfs:subClassOf obo:APOLLO_SV_00000796 ,
+                                obo:OBI_0200171 ,
+                                obo:OBI_0200175 ,
+                                [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
+                                                         owl:onProperty obo:OBI_0000299 ;
+                                                         owl:someValuesFrom obo:OBI_0000648
+                                                       ]
+                                                       [ rdf:type owl:Restriction ;
+                                                         owl:onProperty obo:OBI_0000417 ;
+                                                         owl:someValuesFrom obo:OBI_0200178
+                                                       ]
+                                                     ) ;
+                                  rdf:type owl:Class
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000417 ;
+                                  owl:someValuesFrom obo:OBI_0200172
+                                ] ;
+                obo:IAO_0000111 "k-means clustering"@en ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "A k-means clustering is a data transformation which achieves a class discovery or partitioning objective, which takes as input a collection of objects (represented as points in multidimensional space) and which partitions them into a specified number k of clusters. The algorithm attempts to find the centers of natural clusters in the data. The most common form of the algorithm starts by partitioning the input points into k initial sets, either at random or using some heuristic data. It then calculates the mean point, or centroid, of each set. It constructs a new partition by associating each point with the closest centroid. Then the centroids are recalculated for the new clusters, and the algorithm repeated by alternate applications of these two steps until convergence, which is obtained when the points no longer switch clusters (or alternatively centroids are no longer changed)."@en ;
+                obo:IAO_0000117 "Elisabetta Manduchi" ,
+                                "James Malone"@en ,
+                                "Philippe Rocca-Serra" ;
+                obo:IAO_0000119 "WEB: http://en.wikipedia.org/wiki/K-means"@en ;
+                rdfs:label "k-means clustering"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0200042
+obo:OBI_0200042 rdf:type owl:Class ;
+                rdfs:subClassOf obo:APOLLO_SV_00000796 ,
+                                obo:OBI_0200175 ,
+                                [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
+                                                         owl:onProperty obo:OBI_0000299 ;
+                                                         owl:someValuesFrom obo:OBI_0000648
+                                                       ]
+                                                       [ rdf:type owl:Restriction ;
+                                                         owl:onProperty obo:OBI_0000417 ;
+                                                         owl:someValuesFrom obo:OBI_0200178
+                                                       ]
+                                                     ) ;
+                                  rdf:type owl:Class
+                                ] ;
+                obo:IAO_0000111 "hierarchical clustering"@en ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "A hierarchical clustering is a data transformation which achieves a class discovery objective, which takes as input data item and builds a hierarchy of clusters. The traditional representation of this hierarchy is a tree (visualized by a dendrogram), with the individual input objects at one end (leaves) and a single cluster containing every object at the other (root)."@en ;
+                obo:IAO_0000117 "James Malone"@en ;
+                obo:IAO_0000119 "WEB: http://en.wikipedia.org/wiki/Data_clustering#Hierarchical_clustering"@en ;
+                rdfs:label "hierarchical clustering"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0200049
+obo:OBI_0200049 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0200163 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000293 ;
+                                  owl:someValuesFrom obo:OBI_0000175
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000299 ;
+                                  owl:someValuesFrom obo:OBI_0000662
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000299 ;
+                                  owl:someValuesFrom obo:OBI_0001442
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000417 ;
+                                  owl:someValuesFrom obo:OBI_0000791
+                                ] ;
+                obo:IAO_0000111 "Benjamini and Yekutieli false discovery rate correction method"@en ;
+                obo:IAO_0000112 "The expression set was compared univariately between the stroke patients and controls, gene list was generated using False Discovery Rate correction (Benjamini and Yekutieli)" ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A data transformation in which the Benjamini and Yekutieli method is applied with the aim of correcting false discovery rate" ;
+                obo:IAO_0000116 """2011-03-31: [PRS]. 
+specified input and output of dt which were missing"""@en ;
+                obo:IAO_0000117 "Helen Parkinson" ,
+                                "Philippe Rocca-Serra"@en ;
+                obo:IAO_0000119 "Helen Parkinson" ;
+                rdfs:label "Benjamini and Yekutieli false discovery rate correction method"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0200050
+obo:OBI_0200050 rdf:type owl:Class ;
+                rdfs:subClassOf obo:APOLLO_SV_00000796 ,
+                                obo:OBI_0200175 ,
+                                [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
+                                                         owl:onProperty obo:OBI_0000299 ;
+                                                         owl:someValuesFrom obo:OBI_0000648
+                                                       ]
+                                                       [ rdf:type owl:Restriction ;
+                                                         owl:onProperty obo:OBI_0000417 ;
+                                                         owl:someValuesFrom obo:OBI_0200178
+                                                       ]
+                                                     ) ;
+                                  rdf:type owl:Class
+                                ] ;
+                obo:IAO_0000111 "dimensionality reduction"@en ;
+                obo:IAO_0000114 obo:IAO_0000122 ;
+                obo:IAO_0000115 "A dimensionality reduction is data partitioning which transforms each input m-dimensional vector (x_1, x_2, ..., x_m) into an output n-dimensional vector (y_1, y_2, ..., y_n), where n is smaller than m."@en ;
+                obo:IAO_0000117 "Elisabetta Manduchi"@en ,
+                                "James Malone"@en ,
+                                "Melanie Courtot"@en ,
+                                "Philippe Rocca-Serra" ;
+                obo:IAO_0000118 "data projection" ;
+                obo:IAO_0000119 "PERSON: Elisabetta Manduchi"@en ,
+                                "PERSON: James Malone"@en ,
+                                "PERSON: Melanie Courtot"@en ;
+                rdfs:label "dimensionality reduction"@en .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0200051
+obo:OBI_0200051 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0200050 ;
+                obo:IAO_0000111 "principal components analysis dimensionality reduction"@en ;
+                obo:IAO_0000114 obo:IAO_0000122 ;
+                obo:IAO_0000115 "A principal components analysis dimensionality reduction is a dimensionality reduction achieved by applying principal components analysis and by keeping low-order principal components and excluding higher-order ones."@en ;
+                obo:IAO_0000117 "Elisabetta Manduchi"@en ,
+                                "James Malone"@en ,
+                                "Melanie Courtot"@en ,
+                                "Philippe Rocca-Serra" ;
+                obo:IAO_0000118 "pca data reduction"@en ;
+                obo:IAO_0000119 "PERSON: Elisabetta Manduchi"@en ,
+                                "PERSON: James Malone"@en ,
+                                "PERSON: Melanie Courtot"@en ;
+                rdfs:label "principal components analysis dimensionality reduction"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0200056
+obo:OBI_0200056 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0200170 ,
+                                [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
+                                                         owl:onProperty obo:OBI_0000299 ;
+                                                         owl:someValuesFrom obo:OBI_0000679
+                                                       ]
+                                                       [ rdf:type owl:Restriction ;
+                                                         owl:onProperty obo:OBI_0000417 ;
+                                                         owl:someValuesFrom obo:OBI_0000425
+                                                       ]
+                                                     ) ;
+                                  rdf:type owl:Class
+                                ] ;
+                obo:IAO_0000111 "moving average"@en ;
+                obo:IAO_0000112 "The moving average is often used to handle data from tiling arrays."@en ;
+                obo:IAO_0000114 obo:IAO_0000122 ;
+                obo:IAO_0000115 "A moving average is a data transformation in which center calculations, usually mean calculations, are performed on values within a sliding window across the input data set."@en ;
+                obo:IAO_0000117 "Elisabetta Manduchi"@en ,
+                                "Helen Parkinson"@en ,
+                                "Philippe Rocca-Serra" ;
+                obo:IAO_0000119 "PERSON: Elisabetta Manduchi"@en ,
+                                "PERSON: Helen Parkinson"@en ;
+                rdfs:label "moving average"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0200061
+obo:OBI_0200061 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0200000 ;
+                obo:IAO_0000111 "data imputation"@en ;
+                obo:IAO_0000114 obo:IAO_0000122 ;
+                obo:IAO_0000115 "Imputation is a means of filling in missing data values from a predictive distribution of the missing values.  The predictive distribution can be created either based on a formal statistical model (i,e, a multivariate normal distribution) or an algorithm."@en ;
+                obo:IAO_0000117 "Monnie McGee"@en ;
+                obo:IAO_0000119 "ARTICLE: Little, RJA and Rubin, DB (2002).  Statistical Analysis with Missing Data, Second Edition.  John Wiley: Hoboken New Jersey, pp. 59-60."@en ;
+                rdfs:label "data imputation"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0200066
+obo:OBI_0200066 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0200073 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000293 ;
+                                  owl:someValuesFrom obo:OBI_0000175
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000299 ;
+                                  owl:someValuesFrom obo:OBI_0001265
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000417 ;
+                                  owl:someValuesFrom obo:OBI_0000791
+                                ] ;
+                obo:IAO_0000111 "Holm-Bonferroni family-wise error rate correction method"@en ;
+                obo:IAO_0000112 "t-tests were used with the type I error adjusted for multiple comparisons, Holm's correction (HOLM 1979), and false discovery rate, http://www.genetics.org/cgi/content/full/172/2/1179" ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "a data transformation that performs more than one hypothesis test simultaneously, a closed-test procedure, that  controls the familywise error rate for all the k hypotheses at level α in the strong sense. Objective: multiple testing correction" ;
+                obo:IAO_0000116 """2011-03-14: [PRS]. Class Label has been changed to address the conflict with the definition
+Also added restriction to specify the output to be a FWER adjusted p-value
+
+The 'editor preferred term' should be removed"""@en ;
+                obo:IAO_0000117 "Person:Helen Parkinson" ,
+                                "Philippe Rocca-Serra"@en ;
+                obo:IAO_0000119 "WEB: http://en.wikipedia.org/wiki/Holm%E2%80%93Bonferroni_method" ;
+                rdfs:label "Holm-Bonferroni family-wise error rate correction method"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0200072
+obo:OBI_0200072 rdf:type owl:Class ;
+                owl:equivalentClass [ rdf:type owl:Class ;
+                                      owl:unionOf ( [ rdf:type owl:Restriction ;
+                                                      owl:onProperty obo:OBI_0000299 ;
+                                                      owl:someValuesFrom obo:OBI_0000656
+                                                    ]
+                                                    [ rdf:type owl:Restriction ;
+                                                      owl:onProperty obo:OBI_0000417 ;
+                                                      owl:someValuesFrom obo:OBI_0200174
+                                                    ]
+                                                  )
+                                    ] ;
+                rdfs:subClassOf obo:OBI_0200000 ;
+                obo:IAO_0000111 "curve fitting data transformation"@en ;
+                obo:IAO_0000114 obo:IAO_0000122 ;
+                obo:IAO_0000115 "A curve fitting is a data transformation that has objective curve fitting and that consists of finding a curve which matches a series of data points and possibly other constraints."@en ;
+                obo:IAO_0000117 "Elisabetta Manduchi"@en ,
+                                "James Malone"@en ,
+                                "Melanie Courtot"@en ;
+                obo:IAO_0000119 "WEB: http://en.wikipedia.org/wiki/Curve_fitting"@en ;
+                rdfs:label "curve fitting data transformation"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0200073
+obo:OBI_0200073 rdf:type owl:Class ;
+                owl:equivalentClass [ rdf:type owl:Restriction ;
+                                      owl:onProperty obo:OBI_0000299 ;
+                                      owl:someValuesFrom obo:OBI_0001265
+                                    ] ;
+                rdfs:subClassOf obo:APOLLO_SV_00000796 ,
+                                obo:OBI_0200089 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000417 ;
+                                  owl:someValuesFrom obo:OBI_0000791
+                                ] ;
+                obo:IAO_0000111 "family wise error rate correction method"@en ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "A family wise error rate correction method is a multiple testing procedure that controls the probability of at least one false positive." ;
+                obo:IAO_0000116 """2011-03-31: [PRS]. 
+creating a defined class by specifying the necessary output of dt
+allows correct classification of FWER dt"""@en ;
+                obo:IAO_0000117 "Monnie McGee" ,
+                                "Philippe Rocca-Serra"@en ;
+                obo:IAO_0000118 "FWER correction"@en ;
+                obo:IAO_0000119 "Dudoit, Sandrine and van der Laan, Mark J. (2008) Multiple Testing Procedures with Applications to Genomics.  New York: Springer , p. 19" ;
+                rdfs:label "family wise error rate correction method"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0200078
+obo:OBI_0200078 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0200166 ;
+                obo:IAO_0000111 "descriptive statistical calculation objective"@en ;
+                obo:IAO_0000114 obo:IAO_0000122 ;
+                obo:IAO_0000115 "A descriptive statistical calculation objective is a data transformation objective which concerns any calculation intended to describe a feature of a data set, for example, its center or its variability."@en ;
+                obo:IAO_0000117 "Elisabetta Manduchi"@en ,
+                                "James Malone"@en ,
+                                "Melanie Courtot"@en ,
+                                "Monnie McGee"@en ;
+                obo:IAO_0000119 "PERSON: Elisabetta Manduchi"@en ,
+                                "PERSON: James Malone"@en ,
+                                "PERSON: Melanie Courtot"@en ,
+                                "PERSON: Monnie McGee"@en ;
+                rdfs:label "descriptive statistical calculation objective"@en .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0200079
+obo:OBI_0200079 rdf:type owl:Class ;
+                rdfs:subClassOf obo:APOLLO_SV_00000796 ,
+                                obo:OBI_0200170 ,
+                                obo:OBI_0200181 ,
+                                obo:OBI_0200184 ,
+                                [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
+                                                         owl:onProperty obo:OBI_0000299 ;
+                                                         owl:someValuesFrom obo:OBI_0000674
+                                                       ]
+                                                       [ rdf:type owl:Restriction ;
+                                                         owl:onProperty obo:OBI_0000417 ;
+                                                         owl:someValuesFrom obo:OBI_0200177
+                                                       ]
+                                                     ) ;
+                                  rdf:type owl:Class
+                                ] ,
+                                [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
+                                                         owl:onProperty obo:OBI_0000299 ;
+                                                         owl:someValuesFrom obo:OBI_0000679
+                                                       ]
+                                                       [ rdf:type owl:Restriction ;
+                                                         owl:onProperty obo:OBI_0000417 ;
+                                                         owl:someValuesFrom obo:OBI_0000425
+                                                       ]
+                                                     ) ;
+                                  rdf:type owl:Class
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000417 ;
+                                  owl:someValuesFrom obo:OBI_0200078
+                                ] ;
+                obo:IAO_0000111 "arithmetic mean calculation"@en ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "An arithmetic mean calculation is a descriptive statistics calculation in which the mean is calculated by taking the sum of all of the observations in a data set divided by the total number of observations. It gives a measure of the 'center of gravity' for the data set. It is also known as the first moment."@en ;
+                obo:IAO_0000117 "James Malone"@en ,
+                                "Monnie McGee"@en ,
+                                "Philippe Rocca-Serra" ;
+                obo:IAO_0000119 "PERSON: James Malone"@en ,
+                                "PERSON: Monnie McGee"@en ;
+                obo:IAO_0000232 "From Monnie's file comments - need to add moment_calculation and center_calculation roles but they don't exist yet - (editor note added by James Jan 2008)"@en ;
+                rdfs:label "arithmetic mean calculation"@en .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0200080
+obo:OBI_0200080 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0200000 ;
+                obo:IAO_0000111 "network analysis"@en ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "A data transformation that takes as input data that describes biological networks in terms of the node (a.k.a. vertex) and edge graph elements and their characteristics and generates as output properties of the constituent nodes and edges, the sub-graphs, and the entire network."@en ;
+                obo:IAO_0000117 "Richard Scheuermann"@en ;
+                obo:IAO_0000118 "network topology analysis" ;
+                obo:IAO_0000119 "PERSON: Richard Scheuermann"@en ;
+                rdfs:label "network analysis"@en .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0200081
+obo:OBI_0200081 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0200166 ;
+                obo:IAO_0000111 "sequence analysis objective"@en ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A sequence analysis objective is a data transformation objective which aims to analyse some ordered biological data for sequential patterns."@en ;
+                obo:IAO_0000117 "James Malone" ;
+                obo:IAO_0000119 "PERSON: James Malone" ;
+                rdfs:label "sequence analysis objective"@en .
+
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0200082
+obo:OBI_0200082 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0200000 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000417 ;
+                                  owl:someValuesFrom obo:OBI_0200196
+                                ] ;
+                obo:IAO_0000111 "longitudinal data analysis" ;
+                obo:IAO_0000114 obo:IAO_0000123 ;
+                obo:IAO_0000115 "Longitudinal analysis is a data transformation used to perform repeated observations of the same items over long periods of time."@en ;
+                obo:IAO_0000117 "PERSON: James Malone" ,
+                                "PERSON: Tina Boussard" ;
+                obo:IAO_0000118 "correlation analysis" ,
+                                "longitudinal data analysis"@en ;
+                rdfs:label "longitudinal data analysis"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0200089
+obo:OBI_0200089 rdf:type owl:Class ;
+                owl:equivalentClass [ rdf:type owl:Restriction ;
+                                      owl:onProperty obo:OBI_0000417 ;
+                                      owl:someValuesFrom obo:OBI_0000791
+                                    ] ;
+                rdfs:subClassOf obo:OBI_0000668 ;
+                obo:IAO_0000111 "multiple testing correction method" ;
+                obo:IAO_0000114 obo:IAO_0000123 ;
+                obo:IAO_0000115 "A multiple testing correction method is a hypothesis test performed simultaneously on M > 1 hypotheses.  Multiple testing procedures produce a set of rejected hypotheses that is an estimate for the set of false null hypotheses while controlling for a suitably define Type I error rate" ;
+                obo:IAO_0000117 "Monnie McGee" ;
+                obo:IAO_0000118 "multiple testing procedure"@en ;
+                obo:IAO_0000119 "PAPER: Dudoit, Sandrine and van der Laan, Mark J. (2008) Multiple Testing Procedures with Applications to Genomics.  New York: Springer , p. 9-10." ;
+                rdfs:label "multiple testing correction method"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0200091
+obo:OBI_0200091 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0200166 ;
+                obo:IAO_0000111 "inter-rater reliability objective" ;
+                obo:IAO_0000112 """A study was conducted to determine the inter-rater reliability of common clinical examination procedures proposed to identify patients with lumbar segmental instability.
+
+Examples include joint-probability of agreement, Cohen's kappa and the related Fleiss' kappa, inter-rater correlation, concordance correlation coefficient and intra-class correlation.""" ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "a data transformation objective of determining the concordance or agreement between human judges." ;
+                obo:IAO_0000117 "Person:Alan Ruttenberg" ,
+                                "Person:Helen Parkinson" ;
+                obo:IAO_0000118 "inter-rater agreement" ;
+                obo:IAO_0000119 "http://en.wikipedia.org/wiki/Inter-rater_reliability" ;
+                rdfs:label "inter-rater reliability objective"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0200102
+obo:OBI_0200102 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0200000 ;
+                obo:IAO_0000111 "regression analysis method"@en ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "Regression analysis is a descriptive statistics technique that examines the relation of a dependent variable (response variable) to specified independent variables (explanatory variables). Regression analysis can be used as a descriptive method of data analysis (such as curve fitting) without relying on any assumptions about underlying processes generating the data."@en ;
+                obo:IAO_0000117 "Tina Hernandez-Boussard"@en ;
+                obo:IAO_0000119 "BOOK: Richard A. Berk, Regression Analysis: A Constructive Critique, Sage Publications (2004) 978-0761929048"@en ;
+                rdfs:label "regression analysis method"@en .
+
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0200103
+obo:OBI_0200103 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0200102 ;
+                obo:IAO_0000111 "multiple linear regression analysis"@en ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 """multiple linear regression is a regression method that models the relationship between a dependent variable Y, independent variables Xi, i = 1, ..., p, and a random term epsilon. The model can be written as
+    Y = \\beta_0 + \\beta_1 X_1 + \\beta_2 X_2 + \\cdots +\\beta_p X_p + \\varepsilon
+where \\beta_0 =  0 is the intercept (\"constant\" term), the \\beta_i s  are the respective parameters of independent variables, and p is the number of parameters to be estimated in the linear regression."""@en ;
+                obo:IAO_0000117 "Tina Hernandez-Boussard"@en ;
+                obo:IAO_0000119 "WEB:http://en.wikipedia.org/wiki/Linear_regression"@en ;
+                rdfs:label "multiple linear regression analysis"@en .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0200104
+obo:OBI_0200104 rdf:type owl:Class ;
+                rdfs:subClassOf obo:APOLLO_SV_00000796 ,
+                                obo:OBI_0200102 ,
+                                obo:OBI_0200175 ,
+                                [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
+                                                         owl:onProperty obo:OBI_0000299 ;
+                                                         owl:someValuesFrom obo:OBI_0000648
+                                                       ]
+                                                       [ rdf:type owl:Restriction ;
+                                                         owl:onProperty obo:OBI_0000417 ;
+                                                         owl:someValuesFrom obo:OBI_0200178
+                                                       ]
+                                                     ) ;
+                                  rdf:type owl:Class
+                                ] ;
+                obo:IAO_0000111 "principal component regression"@en ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "The Principal Component Regression method is a regression analysis method that combines the Principal Component Analysis (PCA)spectral decomposition with an Inverse Least Squares (ILS) regression method to create a quantitative model for complex samples. Unlike quantitation methods based directly on Beer's Law which attempt to calculate the absorbtivity coefficients for the constituents of interest from a direct regression of the constituent concentrations onto the spectroscopic responses, the PCR method regresses the concentrations on the PCA scores."@en ;
+                obo:IAO_0000117 "Tina Hernandez-Boussard"@en ;
+                obo:IAO_0000119 "WEB: : http://www.thermo.com/com/cda/resources/resources_detail/1,2166,13414,00.html"@en ;
+                rdfs:label "principal component regression"@en .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0200105
+obo:OBI_0200105 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0200102 ;
+                obo:IAO_0000111 "partial least square regression analysis"@en ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 """Partial least squares regression is an extension of the multiple linear regression model (see, e.g., Multiple Regression or General Stepwise Regression). In its simplest form, a linear model specifies the (linear) relationship between a dependent (response) variable Y, and a set of predictor variables, the X's, so that
+Y = b0 + b1X1 + b2X2 + ... + bpXp
+In this equation b0 is the regression coefficient for the intercept and the bi values are the regression coefficients (for variables 1 through p) computed from the data."""@en ;
+                obo:IAO_0000117 "Tina Hernandez-Boussard"@en ;
+                obo:IAO_0000118 "PLS-RA"@en ;
+                obo:IAO_0000119 "ARTICLE: de Jong, S. (1993). SIMPLS: An alternative approach to partial least squares regression. Chemometrics and Intelligent Laboratory Systems, 18: 251-263."@en ;
+                rdfs:label "partial least square regression analysis"@en .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0200106
+obo:OBI_0200106 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0200000 ;
+                obo:IAO_0000111 "discriminant analysis"@en ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "Discriminant function analysis is used to determine which variables discriminate between two or more naturally occurring groups. Analysis is used to determine which variable(s) are the best predictors of a particular outcome."@en ;
+                obo:IAO_0000117 "Tina Hernandez-Boussard"@en ;
+                obo:IAO_0000119 "WEB: http://www.statsoft.com/textbook/stdiscan.html"@en ;
+                rdfs:label "discriminant analysis"@en .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0200111
+obo:OBI_0200111 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000011 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000293 ;
+                                  owl:someValuesFrom obo:IAO_0000027
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000299 ;
+                                  owl:someValuesFrom [ rdf:type owl:Class ;
+                                                       owl:unionOf ( obo:IAO_0000038
+                                                                     obo:IAO_0000101
+                                                                   )
+                                                     ]
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000293 ;
+                                  owl:allValuesFrom obo:IAO_0000027
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000299 ;
+                                  owl:allValuesFrom [ rdf:type owl:Class ;
+                                                      owl:unionOf ( obo:IAO_0000038
+                                                                    obo:IAO_0000101
+                                                                  )
+                                                    ]
+                                ] ;
+                obo:IAO_0000111 "data visualization" ;
+                obo:IAO_0000112 "Generation of a heatmap from a microarray dataset" ;
+                obo:IAO_0000114 obo:IAO_0000122 ;
+                obo:IAO_0000115 "An planned process that creates images, diagrams or animations from the input data."@en ;
+                obo:IAO_0000117 "Elisabetta Manduchi"@en ,
+                                "James Malone"@en ,
+                                "Melanie Courtot"@en ,
+                                "Tina Boussard"@en ;
+                obo:IAO_0000118 "data encoding as image" ,
+                                "visualization"@en ;
+                obo:IAO_0000119 "PERSON: Elisabetta Manduchi"@en ,
+                                "PERSON: James Malone"@en ,
+                                "PERSON: Melanie Courtot"@en ,
+                                "PERSON: Tina Boussard"@en ;
+                obo:IAO_0000232 """Possible future hierarchy might include this:
+information_encoding
+>data_encoding
+>>image_encoding""" ;
+                rdfs:label "data visualization"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0200114
+obo:OBI_0200114 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0200113 ;
+                obo:IAO_0000111 "euclidean distance calculation"@en ;
+                obo:IAO_0000114 obo:IAO_0000122 ;
+                obo:IAO_0000115 "An euclidean distance calculation is a similarity calculation that attaches to each pair of real number vectors of the same dimension n the square root of the sum of the square differences between corresponding components. The smaller this number, the more similar the two vectors are considered."@en ;
+                obo:IAO_0000117 "Elisabetta Manduchi"@en ;
+                obo:IAO_0000119 "PERSON: Elisabetta Manduchi"@en ;
+                rdfs:label "euclidean distance calculation"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0200115
+obo:OBI_0200115 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0200113 ;
+                obo:IAO_0000111 "pearson correlation coefficient calculation"@en ;
+                obo:IAO_0000114 obo:IAO_0000122 ;
+                obo:IAO_0000115 "A pearson correlation coefficient calculation is a similarity calculation which attaches to each pair of random variables X and Y the ratio of their covariance by the product of their standard deviations. Given a series of n measurements of X and Y written as x_i and y_i where i = 1, 2, ..., n, then their Pearson correlation coefficient refers to the \"sample correlation coefficient\" and is written as the sum over i of the ratios (x_i-xbar)*(y_i-ybar)/((n-1)*s_x*s_y) where xbar and ybar are the sample means of X and Y , s_x and s_y are the sample standard deviations of X and Y. The closer the pearson correlation coefficient is to 1, the more similar the inputs are considered."@en ;
+                obo:IAO_0000117 "Elisabetta Manduchi"@en ;
+                obo:IAO_0000119 "PERSON: Elisabetta Manduchi"@en ,
+                                "WEB: http://en.wikipedia.org/wiki/Correlation"@en ;
+                rdfs:label "pearson correlation coefficient calculation"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0200125
+obo:OBI_0200125 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0200000 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000417 ;
+                                  owl:someValuesFrom obo:OBI_0200189
+                                ] ;
+                obo:IAO_0000111 "data combination"@en ;
+                obo:IAO_0000114 obo:IAO_0000123 ;
+                obo:IAO_0000115 "A data transformation in which individual input data elements and values are merged together into a output set of data elements and values."@en ;
+                obo:IAO_0000117 "Richard Scheuermann"@en ;
+                obo:IAO_0000118 "data pooling" ;
+                obo:IAO_0000119 "editor"@en ;
+                rdfs:label "data combination"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0200126
+obo:OBI_0200126 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0200080 ;
+                obo:IAO_0000111 "network graph construction"@en ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "A network analysis in which an input data set describing objects and relationships between objects is transformed into an output representation of these objects as nodes and the relationships as edges of a network graph."@en ;
+                obo:IAO_0000117 "Richard Scheuermann"@en ;
+                obo:IAO_0000119 "PERSON: Richard Scheuermann"@en ;
+                rdfs:label "network graph construction"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0200156
+obo:OBI_0200156 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0200000 ;
+                obo:IAO_0000111 "data partitioning"@en ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "Data partitioning is a data transformation with the objective of partitioning or separating input data into output subsets."@en ;
+                obo:IAO_0000117 "James Malone"@en ;
+                obo:IAO_0000119 "PERSON: Melanie Courtot"@en ,
+                                "PERSON: Richard Scheuermann"@en ,
+                                "PERSON: Ryan Brinkman"@en ;
+                rdfs:label "data partitioning"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0200160
+obo:OBI_0200160 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0200089 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000417 ;
+                                  owl:someValuesFrom obo:OBI_0000791
+                                ] ;
+                obo:IAO_0000111 "generalized family wise error rate correction method"@en ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "A generalized FWER correction method is a multiple testing procedure that controls the probability of at least k+1 false positives, where k is a user-supplied integer." ;
+                obo:IAO_0000117 "Monnie McGee" ;
+                obo:IAO_0000118 "gFWER correction"@en ;
+                obo:IAO_0000119 "Dudoit, Sandrine and van der Laan, Mark J. (2008) Multiple Testing Procedures with Applications to Genomics.  New York: Springer , p. 19" ;
+                rdfs:label "generalized family wise error rate correction method"@en .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0200163
+obo:OBI_0200163 rdf:type owl:Class ;
+                owl:equivalentClass [ rdf:type owl:Restriction ;
+                                      owl:onProperty obo:OBI_0000299 ;
+                                      owl:someValuesFrom obo:OBI_0001442
+                                    ] ;
+                rdfs:subClassOf obo:APOLLO_SV_00000796 ,
+                                obo:OBI_0200089 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000293 ;
+                                  owl:someValuesFrom obo:OBI_0000175
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000417 ;
+                                  owl:someValuesFrom obo:OBI_0000791
+                                ] ;
+                obo:IAO_0000111 "false discovery rate correction method"@en ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "The false discovery rate is a  data transformation used in multiple hypothesis testing to correct for multiple comparisons. It controls the expected proportion of incorrectly rejected null hypotheses (type I errors) in a list of rejected hypotheses. It is a less conservative comparison procedure with greater power than familywise error rate (FWER) control, at a cost of increasing the likelihood of obtaining type I errors. ." ;
+                obo:IAO_0000116 """2011-03-31: [PRS]. 
+creating a defined class by specifying the necessary output of dt
+allows correct classification of FDR dt"""@en ;
+                obo:IAO_0000117 "Monnie McGee" ,
+                                "Philippe Rocca-Serra"@en ;
+                obo:IAO_0000118 "FDR correction method"@en ;
+                obo:IAO_0000119 "Dudoit, Sandrine and van der Laan, Mark J. (2008) Multiple Testing Procedures with Applications to Genomics.  New York: Springer , p. 21 and http://www.wikidoc.org/index.php/False_discovery_rate" ;
+                rdfs:label "false discovery rate correction method"@en .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0200163
+obo:OBI_0200163 rdf:type owl:Class ;
+                owl:equivalentClass [ rdf:type owl:Restriction ;
+                                      owl:onProperty obo:OBI_0000299 ;
+                                      owl:someValuesFrom obo:OBI_0001442
+                                    ] ;
+                rdfs:subClassOf obo:APOLLO_SV_00000796 ,
+                                obo:OBI_0200089 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000293 ;
+                                  owl:someValuesFrom obo:OBI_0000175
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000417 ;
+                                  owl:someValuesFrom obo:OBI_0000791
+                                ] ;
+                obo:IAO_0000111 "false discovery rate correction method"@en ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "The false discovery rate is a  data transformation used in multiple hypothesis testing to correct for multiple comparisons. It controls the expected proportion of incorrectly rejected null hypotheses (type I errors) in a list of rejected hypotheses. It is a less conservative comparison procedure with greater power than familywise error rate (FWER) control, at a cost of increasing the likelihood of obtaining type I errors. ." ;
+                obo:IAO_0000116 """2011-03-31: [PRS]. 
+creating a defined class by specifying the necessary output of dt
+allows correct classification of FDR dt"""@en ;
+                obo:IAO_0000117 "Monnie McGee" ,
+                                "Philippe Rocca-Serra"@en ;
+                obo:IAO_0000118 "FDR correction method"@en ;
+                obo:IAO_0000119 "Dudoit, Sandrine and van der Laan, Mark J. (2008) Multiple Testing Procedures with Applications to Genomics.  New York: Springer , p. 21 and http://www.wikidoc.org/index.php/False_discovery_rate" ;
+                rdfs:label "false discovery rate correction method"@en .
+
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0200169
+obo:OBI_0200169 rdf:type owl:Class ;
+                owl:equivalentClass [ rdf:type owl:Class ;
+                                      owl:unionOf ( [ rdf:type owl:Restriction ;
+                                                      owl:onProperty obo:OBI_0000299 ;
+                                                      owl:someValuesFrom obo:OBI_0000451
+                                                    ]
+                                                    [ rdf:type owl:Restriction ;
+                                                      owl:onProperty obo:OBI_0000417 ;
+                                                      owl:someValuesFrom obo:OBI_0200167
+                                                    ]
+                                                  )
+                                    ] ;
+                rdfs:subClassOf obo:OBI_0200000 ;
+                obo:IAO_0000111 "normalization data transformation"@en ;
+                obo:IAO_0000114 obo:IAO_0000123 ;
+                obo:IAO_0000115 "A normalization data transformation is a data transformation that has objective normalization."@en ;
+                obo:IAO_0000117 "James Malone" ;
+                obo:IAO_0000119 "PERSON: James Malone"@en ;
+                rdfs:label "normalization data transformation"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0200170
+obo:OBI_0200170 rdf:type owl:Class ;
+                owl:equivalentClass [ rdf:type owl:Class ;
+                                      owl:unionOf ( [ rdf:type owl:Restriction ;
+                                                      owl:onProperty obo:OBI_0000299 ;
+                                                      owl:someValuesFrom obo:OBI_0000679
+                                                    ]
+                                                    [ rdf:type owl:Restriction ;
+                                                      owl:onProperty obo:OBI_0000417 ;
+                                                      owl:someValuesFrom obo:OBI_0000425
+                                                    ]
+                                                  )
+                                    ] ;
+                rdfs:subClassOf obo:OBI_0200000 ;
+                obo:IAO_0000111 "averaging data transformation"@en ;
+                obo:IAO_0000114 obo:IAO_0000123 ;
+                obo:IAO_0000115 "An averaging data transformation is a data transformation that has objective averaging."@en ;
+                obo:IAO_0000117 "James Malone" ;
+                obo:IAO_0000119 "PERSON: James Malone"@en ;
+                rdfs:label "averaging data transformation"@en .
+
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0200185
+obo:OBI_0200185 rdf:type owl:Class ;
+                owl:equivalentClass [ rdf:type owl:Restriction ;
+                                      owl:onProperty obo:OBI_0000417 ;
+                                      owl:someValuesFrom obo:OBI_0200183
+                                    ] ;
+                rdfs:subClassOf obo:OBI_0200000 ;
+                obo:IAO_0000111 "scaling data transformation"@en ;
+                obo:IAO_0000114 obo:IAO_0000122 ;
+                obo:IAO_0000115 "A scaling data transformation is a data transformation that has objective scaling."@en ;
+                obo:IAO_0000117 "James Malone"@en ;
+                obo:IAO_0000119 "PERSON: James Malone"@en ;
+                rdfs:label "scaling data transformation"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0200186
+obo:OBI_0200186 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0200168 ;
+                obo:IAO_0000111 "error correction objective"@en ;
+                obo:IAO_0000112 "Application of a multiple testing correction method" ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "An error correction objective is a data transformation objective where the aim is to remove (correct for) erroneous contributions arising from the input data, or the transformation itself."@en ;
+                obo:IAO_0000117 "James Malone, Helen Parkinson"@en ;
+                obo:IAO_0000119 "PERSON: James Malone" ;
+                rdfs:label "error correction objective"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0200188
+obo:OBI_0200188 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0200172 ;
+                obo:IAO_0000111 "cross validation objective"@en ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "A cross validation objective is a data transformation objective in which the aim is to partition a sample of data into subsets such that the analysis is initially performed on a single subset, while the other subset(s) are retained for subsequent use in confirming and validating the initial analysis."@en ;
+                obo:IAO_0000117 "James Malone"@en ;
+                obo:IAO_0000118 "rotation estimation objective"@en ;
+                obo:IAO_0000119 "WEB: http://en.wikipedia.org/wiki/Cross_validation" ;
+                rdfs:label "cross validation objective"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0200188
+obo:OBI_0200188 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0200172 ;
+                obo:IAO_0000111 "cross validation objective"@en ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "A cross validation objective is a data transformation objective in which the aim is to partition a sample of data into subsets such that the analysis is initially performed on a single subset, while the other subset(s) are retained for subsequent use in confirming and validating the initial analysis."@en ;
+                obo:IAO_0000117 "James Malone"@en ;
+                obo:IAO_0000118 "rotation estimation objective"@en ;
+                obo:IAO_0000119 "WEB: http://en.wikipedia.org/wiki/Cross_validation" ;
+                rdfs:label "cross validation objective"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0200196
+obo:OBI_0200196 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0200166 ;
+                obo:IAO_0000111 "correlation study objective" ;
+                obo:IAO_0000114 obo:IAO_0000123 ;
+                obo:IAO_0000115 "A data transformation objective in which correlation is obtained (often measured as a correlation coefficient, ρ) which indicates the strength and direction of a relationship between two random variables." ;
+                obo:IAO_0000117 "PERSON: Tina Boussard" ;
+                rdfs:label "correlation study objective" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0300310
+obo:OBI_0300310 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000115 ;
+                obo:IAO_0000111 "sequential design" ;
+                obo:IAO_0000112 "PMID: 17710740.Pharm Stat. 2007 Aug 20.Sequential design approaches for bioequivalence studies with crossover designs." ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "Any design in which the decision as to whether to enroll the next patient, pair of patients, or block of patients is determined by whether the cumulative treatment difference for all previous patients is within specified limits.  Enrollment is continued if the difference does not exceed the limits.  It is terminated if it does" ;
+                obo:IAO_0000117 "Philippe Rocca-Serra" ;
+                obo:IAO_0000119 "MUSC" ;
+                obo:IAO_0000232 "Provenance: OCI" ;
+                rdfs:label "sequential design" .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0300311
+obo:OBI_0300311 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0500000 ;
+                obo:IAO_0000111 "observation design" ;
+                obo:IAO_0000112 "PMID: 12387964.Lancet. 2002 Oct 12;360(9340):1144-9.Deficiency of antibacterial peptides in patients with morbus Kostmann: an observation study." ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "observation design is a study design in which subjects are monitored in the absence of any active intervention by experimentalists." ;
+                obo:IAO_0000117 "Philippe Rocca-Serra" ;
+                obo:IAO_0000119 "OBI branch derived" ;
+                rdfs:label "observation design" .
+
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0302840
+obo:OBI_0302840 rdf:type owl:Class ;
+                rdfs:subClassOf obo:IAO_0000030 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000312 ;
+                                  owl:someValuesFrom obo:OBI_0302914
+                                ] ;
+                obo:IAO_0000111 "curated information" ;
+                obo:IAO_0000112 "PMID: 17344875: A curated compendium of phosphorylation motifs.Nat Biotechnol. 2007 Mar;25(3):285-6." ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "An information content entity that has undergone a digital curation performed by a curator for accuracy checks and compliance with curation requirements. Information which has been assessed for accuracy by domain experts." ;
+                obo:IAO_0000116 "2009-11-10 Bjoern Peters. Need to check if this was intended. overlap with 'edited information', and has the same logical restrictions." ,
+                                "2010-01-31 Philippe Rocca-Serra: restriction now changed to be the output of a digital curation process + reflected in example of usage and reference" ;
+                obo:IAO_0000117 "Person:Bjoern Peters" ,
+                                "Person:Philippe Rocca-Serra" ;
+                obo:IAO_0000119 "OBI" ;
+                rdfs:label "curated information"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0302846
+obo:OBI_0302846 rdf:type owl:Class ;
+                owl:equivalentClass [ rdf:type owl:Restriction ;
+                                      owl:onProperty obo:OBI_0000312 ;
+                                      owl:someValuesFrom obo:OBI_0302900
+                                    ] ;
+                rdfs:subClassOf obo:BFO_0000023 ;
+                obo:IAO_0000111 "randomized group participant role" ;
+                obo:IAO_0000112 "A person enrolled in a randomized clinical trial bears a randomized group participant role" ;
+                obo:IAO_0000114 obo:IAO_0000123 ;
+                obo:IAO_0000115 "a role that borne by an organism and realized by some group randomization process" ;
+                obo:IAO_0000117 "Person:Helen Parkinson" ,
+                                "Philippe Rocca-Serra" ;
+                rdfs:label "randomized group participant role"@en .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0302868
+obo:OBI_0302868 rdf:type owl:Class ;
+                owl:equivalentClass [ rdf:type owl:Restriction ;
+                                      owl:onProperty obo:OBI_0000312 ;
+                                      owl:someValuesFrom obo:OBI_0200029
+                                    ] ;
+                rdfs:subClassOf obo:OBI_0000451 ;
+                obo:IAO_0000111 "mean-centered data" ;
+                obo:IAO_0000114 obo:IAO_0000123 ;
+                obo:IAO_0000115 "a data item which has been processed by a mean centering data transformation where each output value is produced by subtracting the mean from the inout value" ;
+                obo:IAO_0000117 "Person:Helen Parkinson" ,
+                                "Person:Philippe Rocca-Serra" ;
+                rdfs:label "mean-centered data"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0302874
+obo:OBI_0302874 rdf:type owl:Class ;
+                rdfs:subClassOf obo:IAO_0000310 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000312 ;
+                                  owl:someValuesFrom obo:OBI_0302908
+                                ] ;
+                obo:IAO_0000111 "edited document" ;
+                obo:IAO_0000112 "The OBI manuscript is (much) edited imformation" ;
+                obo:IAO_0000114 obo:IAO_0000122 ;
+                obo:IAO_0000115 "A document which is the output of a document editing process" ;
+                obo:IAO_0000117 "Person:Bjoern Peters" ,
+                                "Philippe Rocca-Serra" ;
+                rdfs:label "edited document"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0302884
+obo:OBI_0302884 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0600014 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000417 ;
+                                  owl:someValuesFrom obo:OBI_0000681
+                                ] ;
+                obo:IAO_0000111 "extraction" ;
+                obo:IAO_0000112 "nucleic acid extraction using phenol chloroform" ;
+                obo:IAO_0000114 obo:IAO_0000123 ;
+                obo:IAO_0000115 "A material separation in which a desired component of an input material is separated from the remainder" ;
+                obo:IAO_0000116 """Current the output of material processing defined as the molecular entity, main component in the output material entity, rather than the material entity that have grain molecular entity. 
+'nucleic acid extract' is the output of 'nucleic acid extraction' and has grain 'nucleic acid'. However, the output of 'nucleic acid extraction' is 'nucleic acid' rather than 'nucleic acid extract'. We are aware of this issue and will work it out in the future."""@en ;
+                obo:IAO_0000117 "Person:Bjoern Peters" ,
+                                "Philippe Rocca-Serra" ;
+                rdfs:label "extraction"@en .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0302886
+obo:OBI_0302886 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0600014 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000417 ;
+                                  owl:someValuesFrom obo:OBI_0000681
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:RO_0000057 ;
+                                  owl:someValuesFrom obo:OBI_0400106
+                                ] ;
+                obo:IAO_0000111 "centrifugation" ;
+                obo:IAO_0000112 "PMID: 18428461.Purification of oligodendrocytes and their progenitors using immunomagnetic separation and Percoll gradient centrifugation. Curr Protoc Neurosci. 2001 May;Chapter 3:Unit 3.12."@en ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "centrifugation is a process separating molecules by size or density using centrifugal forces generated by a spinning rotor. G-forces of several hundred thousand times gravity are generated in ultracentrifugation"@en ;
+                obo:IAO_0000117 "Philippe Rocca-Serra" ;
+                obo:IAO_0000119 "adapted from http://www.fao.org/DOCREP/003/X3910E/X3910E06.htm" ;
+                rdfs:label "centrifugation"@en .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0302887
+obo:OBI_0302887 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000094 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000417 ;
+                                  owl:someValuesFrom obo:OBI_0000456
+                                ] ;
+                obo:IAO_0000111 "staining" ;
+                obo:IAO_0000112 "PMID: 18540298. Role of modified bleach method in staining of acid-fast bacilli in lymph node aspirates. Acta Cytol. 2008 May-Jun;52(3):325-8."@en ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "Staining is a process which results in the addition a class-specific (DNA, proteins, lipids, carbohydrates) dye to a substrate to qualify or quantify the presence of a specific compound."@en ;
+                obo:IAO_0000117 "Philippe Rocca-Serra" ;
+                obo:IAO_0000119 "adapted from Wikipedia: http://en.wikipedia.org/wiki/Staining" ;
+                rdfs:label "staining"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0302900
+obo:OBI_0302900 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0600015 ;
+                obo:IAO_0000111 "group randomization" ;
+                obo:IAO_0000112 "PMID: 18349405. Randomization reveals unexpected acute leukemias in Southwest Oncology Group prostate cancer trial. J Clin Oncol. 2008 Mar 20;26(9):1532-6."@en ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A group assignment which relies on chance to assign materials to a group of materials in order to avoid bias in experimental set up."@en ;
+                obo:IAO_0000117 "Philippe Rocca-Serra" ;
+                obo:IAO_0000119 "adapted from wikipedia [http://en.wikipedia.org/wiki/Randomization]" ;
+                rdfs:label "group randomization"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0302908
+obo:OBI_0302908 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000011 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000293 ;
+                                  owl:someValuesFrom obo:IAO_0000310
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000299 ;
+                                  owl:someValuesFrom obo:OBI_0302874
+                                ] ;
+                obo:IAO_0000111 "document editing" ;
+                obo:IAO_0000112 """Wax DB, Beilin Y, Hossain S, Lin HM, Reich DL.
+Manual editing of automatically recorded data in an anesthesia information management system. Anesthesiology. 2008 Nov;109(5):811-5. PMID: 18946292"""@en ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "is a planned process with specified input original document and specified output edited document"@en ;
+                obo:IAO_0000117 "Philippe Rocca-Serra and OBI consortium" ;
+                obo:IAO_0000119 "adapted from wikipedia" ;
+                rdfs:label "document editing"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0302911
+obo:OBI_0302911 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000011 ;
+                obo:IAO_0000111 "validation" ;
+                obo:IAO_0000112 "PMID: 18557814 . Chemical and genetic validation of dihydrofolate reductase-thymidylate synthase as a drug target in African trypanosomes. Mol Microbiol. 2008 Jun 16."@en ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "a planned process with objective to check that the accuracy or the quality of a claim or prediction  satisfies some criteria and which is assessed by comparing with independent results"@en ;
+                obo:IAO_0000117 "Philippe Rocca-Serra" ;
+                obo:IAO_0000119 "adapted from wordnet (wkipedia)" ;
+                rdfs:label "validation"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0302914
+obo:OBI_0302914 rdf:type owl:Class ;
+                rdfs:subClassOf obo:IAO_0000572 ;
+                obo:IAO_0000111 "digital curation" ;
+                obo:IAO_0000112 "PMID: 16901087. Supporting the curation of biological databases with reusable text mining.Genome Inform. 2005;16(2):32-44."@en ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "Digital curation is the process of establishing and developing long term repositories of digital assets for current and future reference by researchers, scientists, and historians, and scholars generally."@en ;
+                obo:IAO_0000117 "Philippe Rocca-Serra" ;
+                obo:IAO_0000119 "wikipedia" ;
+                rdfs:label "digital curation"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0400007
+obo:OBI_0400007 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000968 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:RO_0000085 ;
+                                  owl:someValuesFrom obo:OBI_0000393
+                                ] ;
+                obo:IAO_0000111 "analog-to-digital converter" ;
+                obo:IAO_0000112 "The analog to digital converter transformed the analog output from the photomultiplier tube to a digital signal for collection." ;
+                obo:IAO_0000114 obo:IAO_0000123 ;
+                obo:IAO_0000115 "An analog-to-digital_converter is an instrument that converts an infinite resolution analog signal to a finite resolution digital signal." ;
+                obo:IAO_0000117 "John Quinn" ,
+                                "Melanie Courtot" ;
+                obo:IAO_0000118 "A-D" ,
+                                "A2D" ;
+                obo:IAO_0000119 "http://en.wiktionary.org/wiki/Analog-to-Digital_Converter" ;
+                rdfs:label "analog-to-digital converter" .
+
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0400013
+obo:OBI_0400013 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0400079 ;
+                obo:IAO_0000111 "band pass filter" ;
+                obo:IAO_0000112 "530/30 BP filter, 585/42 BP filter" ;
+                obo:IAO_0000114 obo:IAO_0000123 ;
+                obo:IAO_0000115 "A band pass filter is an optical filter that passes wavelengths of light within a certain range and rejects (attenuates) frequencies outside that range. The passed wavelengths are indicated in the specifications of the filter and its name. A 480/20 band-pass filter pass light with at wavelengths of 460 to 500 nm and attenuates all others." ;
+                obo:IAO_0000117 "Person:John Quinn" ;
+                obo:IAO_0000119 "http://en.wikipedia.org/wiki/Band_pass_filter" ;
+                rdfs:label "band pass filter" .
+
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0400064
+obo:OBI_0400064 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0400065 ;
+                obo:IAO_0000111 "laser" ;
+                obo:IAO_0000112 "A laser is the most common way to irradiate a cell in a flow cytometer." ;
+                obo:IAO_0000114 obo:IAO_0000123 ;
+                obo:IAO_0000115 "A laser (acronym for light amplification by the stimulated emission of radiation) is a light source that emits photons of the same characteristics in a coherent beam. A laser uses a solid, liquid or gaseous lasing medium, that contains molecules, of which some atoms have electrons that emit photons of the same frequency when falling back to their normal orbital after excitation (pumping) by external means A laser is the most common way to irradiate a cell in a flow cytometer." ;
+                obo:IAO_0000117 "Daniel Schober" ;
+                obo:IAO_0000118 "light amplification by the stimulated emission of radiation" ;
+                obo:IAO_0000119 "John Quinn" ,
+                                "http://en.wikipedia.org/wiki/Laser" ;
+                rdfs:label "laser" .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0400065
+obo:OBI_0400065 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0001032 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:RO_0000085 ;
+                                  owl:someValuesFrom obo:OBI_0000367
+                                ] ;
+                obo:IAO_0000111 "light source" ;
+                obo:IAO_0000114 obo:IAO_0000123 ;
+                obo:IAO_0000115 "A light source is an optical subsystem that provides light for use in a distant area using a delivery system (e.g., fiber optics). Light sources may include one of a variety of lamps (e.g., xenon, halogen, mercury). Most light sources are operated from line power, but some may be powered from batteries. They are mostly used in endoscopic, microscopic, and other examination and/or in surgical procedures. The light source is part of the optical subsystem. In a flow cytometer the light source directs high intensity light at particles at the interrogation point. The light source in a flow cytometer is usually a laser." ;
+                obo:IAO_0000117 "Elizabeth M. Goralczyk" ,
+                                "John Quinn" ,
+                                "Olga Tchuvatkina" ;
+                obo:IAO_0000119 "Practical Flow Cytometry 4th Edition, Howard Shapiro, ISBN-10: 0471411256, ISBN-13: 978-0471411253" ;
+                rdfs:label "light source" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0400087
+obo:OBI_0400087 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0400101 ;
+                obo:IAO_0000111 "preamplifier" ;
+                obo:IAO_0000112 "Built in preamplifier in a Hamamatsu H9656 PMT" ;
+                obo:IAO_0000114 obo:IAO_0000123 ;
+                obo:IAO_0000115 "A preamplifier is part of the electronics subsystem. It converts the current output from its associated detector to a voltage. The preamplifier is the first stage in analog electronics signal processing." ;
+                obo:IAO_0000117 "John Quinn" ;
+                obo:IAO_0000119 "Practical Flow Cytometry 4th Edition, Howard Shapiro, ISBN-10: 0471411256, ISBN-13: 978-0471411253" ;
+                rdfs:label "preamplifier" .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0400100
+obo:OBI_0400100 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000967 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:RO_0000085 ;
+                                  owl:someValuesFrom obo:OBI_0000370
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:RO_0000085 ;
+                                  owl:someValuesFrom obo:OBI_0000383
+                                ] ;
+                obo:IAO_0000111 "syringe pump" ;
+                obo:IAO_0000112 "NE-1000 Single Syringe Pump" ;
+                obo:IAO_0000114 obo:IAO_0000123 ;
+                obo:IAO_0000115 "Part of the fluidics system. A syringe pump can be used to inject the sample fluid and cells into the sheath fluid in the flow chamber. Syringe pumps are useful for creating stable flow rates." ;
+                obo:IAO_0000117 "Person:John Quinn" ;
+                obo:IAO_0000119 "http://www.answers.com/topic/syringe, 2007-05-11" ;
+                rdfs:label "syringe pump" .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0400101
+obo:OBI_0400101 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000968 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:RO_0000085 ;
+                                  owl:someValuesFrom obo:OBI_0000395
+                                ] ;
+                obo:IAO_0000111 "voltage amplifier" ;
+                obo:IAO_0000112 "Linear amplifier, log amplifier, microwave amplifier" ;
+                obo:IAO_0000114 obo:IAO_0000123 ;
+                obo:IAO_0000115 "A voltage amplifier is a device that amplifies the voltage signal." ;
+                obo:IAO_0000117 "Frank Gibson" ,
+                                "John Quinn" ;
+                obo:IAO_0000119 "http://en.wiktionary.org/wiki/amplifier" ;
+                rdfs:label "voltage amplifier" .
+
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0400103
+obo:OBI_0400103 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000832 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:RO_0000085 ;
+                                  owl:someValuesFrom obo:OBI_0000453
+                                ] ;
+                obo:IAO_0000111 "DNA sequencer" ;
+                obo:IAO_0000112 "ABI 377 DNA Sequencer, ABI 310 DNA Sequencer" ;
+                obo:IAO_0000114 obo:IAO_0000122 ;
+                obo:IAO_0000115 "A DNA sequencer is an instrument that determines the order of deoxynucleotides in deoxyribonucleic acid sequences." ;
+                obo:IAO_0000117 "Trish Whetzel" ;
+                obo:IAO_0000119 "MO" ;
+                rdfs:label "DNA sequencer" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0400106
+obo:OBI_0400106 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000832 ,
+                                obo:OBI_0000932 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000051 ;
+                                  owl:someValuesFrom [ rdf:type owl:Restriction ;
+                                                       owl:onProperty obo:RO_0000085 ;
+                                                       owl:someValuesFrom obo:OBI_0000370
+                                                     ]
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:RO_0000085 ;
+                                  owl:someValuesFrom obo:OBI_0000453
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:RO_0000085 ;
+                                  owl:someValuesFrom [ owl:intersectionOf ( obo:OBI_0000372
+                                                                            [ rdf:type owl:Restriction ;
+                                                                              owl:onProperty obo:BFO_0000054 ;
+                                                                              owl:allValuesFrom obo:OBI_0302886
+                                                                            ]
+                                                                          ) ;
+                                                       rdf:type owl:Class
+                                                     ]
+                                ] ;
+                obo:IAO_0000111 "centrifuge" ;
+                obo:IAO_0000114 obo:IAO_0000122 ;
+                obo:IAO_0000115 "A device with a rapidly rotating container that applies centrifugal force to its contents" ;
+                obo:IAO_0000117 "Melanie Courtot" ,
+                                "Person: Jennifer Fostel" ,
+                                "Trish Whetzel" ;
+                obo:IAO_0000119 "http://en.wikipedia.org/wiki/Centrifuge" ;
+                rdfs:label "centrifuge" .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0400107
+obo:OBI_0400107 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000968 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:RO_0000085 ;
+                                  owl:someValuesFrom obo:OBI_0000392
+                                ] ;
+                obo:IAO_0000111 "computer" ;
+                obo:IAO_0000112 "Apple PowerBook, Dell OptiPlex" ;
+                obo:IAO_0000114 obo:IAO_0000122 ;
+                obo:IAO_0000115 "A computer is an instrument which manipulates (stores, retrieves, and processes) data according to a list of instructions." ;
+                obo:IAO_0000117 "Melanie Courtot" ,
+                                "Trish Whetzel" ;
+                obo:IAO_0000119 "http://en.wikipedia.org/wiki/Computer" ;
+                rdfs:label "computer" .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0400142
+obo:OBI_0400142 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000968 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:RO_0000085 ;
+                                  owl:someValuesFrom obo:OBI_0000384
+                                ] ;
+                obo:IAO_0000111 "power supply" ;
+                obo:IAO_0000112 "A AC/DC transformer that generates the reqired power for an electrophoresis apparatus" ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "A power supply is an device or part of a device that permits the required application of a defined electrical charge to an instrument. The power supply may permit the defined application of a given amount of current for a defined length of time." ;
+                obo:IAO_0000117 "Daniel Schober" ,
+                                "Frank Gibson" ;
+                obo:IAO_0000118 "PSU" ,
+                                "electrical power supply" ,
+                                "power pack" ,
+                                "power supply unit" ;
+                obo:IAO_0000119 "PERSON: Daniel Schober" ,
+                                "sep:00093" ;
+                obo:IAO_0000232 "was power_pack, maps to SEP electrical_power_supply" ;
+                rdfs:label "power supply" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0400158
+obo:OBI_0400158 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000968 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:RO_0000085 ;
+                                  owl:someValuesFrom obo:OBI_0000393
+                                ] ;
+                obo:IAO_0000111 "digital-to-analog converter" ;
+                obo:IAO_0000112 "A digital-to-analog_converter is used to convert a computergenerated discrete signal into a continuous analog one, e.g. a sound." ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A digital-to-analog_converter is an instrument that converts a finite resolution digital signal into an infinite resolution analog signal." ;
+                obo:IAO_0000117 "Daniel Schober" ;
+                obo:IAO_0000119 "PERSON: Daniel Schober" ;
+                rdfs:label "digital-to-analog converter" .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0400169
+obo:OBI_0400169 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000398 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:RO_0000085 ;
+                                  owl:someValuesFrom obo:OBI_0000369
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:RO_0000085 ;
+                                  owl:someValuesFrom obo:OBI_0000397
+                                ] ;
+                obo:IAO_0000111 "microscope" ;
+                obo:IAO_0000112 "PMID:18466942. A light and transmission electron microscope study of hepatic portal tracts in the rhesus monkey (Macacus rhesus). Tissue Cell. 2008 May 6" ;
+                obo:IAO_0000114 obo:IAO_0000123 ;
+                obo:IAO_0000115 "A microscope is an instrument which magnifies the view on objects (too small to be viewed by the naked eye) under increased resolution. A microscope can be an optical instrument but also and electronic instrument. There are various kind of optical microscopes, e.g confocal microscope, epifluoresence microscope)" ;
+                obo:IAO_0000117 "PERSON: Phillippe Rocca-Serra" ;
+                obo:IAO_0000119 "wikipedia" ;
+                rdfs:label "microscope" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0400170
+obo:OBI_0400170 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000968 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:RO_0000085 ;
+                                  owl:someValuesFrom obo:OBI_0000399
+                                ] ;
+                obo:IAO_0000111 "microscope slide" ;
+                obo:IAO_0000112 "PMID: 9668975.Microscope slide for enhanced analysis of DNA damage using the comet assay." ;
+                obo:IAO_0000114 obo:IAO_0000123 ;
+                obo:IAO_0000115 "A microscope slide is a device usually made of glass which is used as a solid matrix for (biological) material deposited on its surface and which is compatible for use with a microscope instrument" ;
+                obo:IAO_0000117 "PERSON: Phillippe Rocca-Serra" ;
+                obo:IAO_0000119 "OBI biomaterial branch" ;
+                rdfs:label "microscope slide" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0500000
+obo:OBI_0500000 rdf:type owl:Class ;
+                rdfs:subClassOf obo:IAO_0000104 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000051 ;
+                                  owl:someValuesFrom obo:OBI_0000272
+                                ] ;
+                obo:IAO_0000111 "study design"@en ;
+                obo:IAO_0000112 "a matched pairs study design describes criteria by which subjects are identified as pairs which then undergo the same protocols, and the data generated is analyzed by comparing the differences between the paired subjects, which constitute the results of the executed study design."@en ;
+                obo:IAO_0000114 obo:IAO_0000122 ;
+                obo:IAO_0000115 "A plan specification comprised of protocols (which may specify how and what kinds of data will be gathered) that are executed as part of an investigation and is realized during a study design execution." ;
+                obo:IAO_0000116 "Editor note: there is at least an implicit restriction on the kind of data transformations that can be done based on the measured data available." ;
+                obo:IAO_0000117 "PERSON: Chris Stoeckert" ;
+                obo:IAO_0000118 "experimental design"@en ;
+                obo:IAO_0000232 "rediscussed at length (MC/JF/BP). 12/9/08). The definition was clarified to differentiate it from protocol."@en ;
+                obo:IAO_0000412 <http://purl.obolibrary.org/obo/obi.owl> ;
+                rdfs:label "study design"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0500001
+obo:OBI_0500001 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0500000 ;
+                obo:IAO_0000111 "clinical study design" ;
+                obo:IAO_0000112 "PMID: 17655677.J Cardiovasc Electrophysiol. 2007 Aug;18(9):965-71.Biventricular versus right ventricular pacing in patients with AV block (BLOCK HF): clinical study design and rationale." ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "Plan for the precise procedure to be followed in a clinical trial, including planned and actual timing of events, choice of control group, method of allocating treatments, blinding methods; assigns a subject to pass through one or more epochs in the course of a trial. Specific design elements, e.g., crossover, parallel; dose-escalation [Modified from Pocock, Clinical Trials: A Practical Approach]" ;
+                obo:IAO_0000116 "The definition needs to be extended to other things than simply patients" ;
+                obo:IAO_0000117 "PlanAndPlannedProcess Branch" ;
+                obo:IAO_0000119 "Clinical Research Glossary Version 4.0 CDICS glossary group" ;
+                rdfs:label "clinical study design" .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0500002
+obo:OBI_0500002 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000115 ;
+                obo:IAO_0000111 "repeated measure design" ;
+                obo:IAO_0000112 "PMID: 10959922.J Biopharm Stat. 2000 Aug;10(3):433-45.Equivalence in test assay method comparisons for the repeated-measure, matched-pair design in medical device studies: statistical considerations." ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "a study design which use the same individuals and exposure them to a set of conditions. The effect of order and practice can be confounding factor in such designs" ;
+                obo:IAO_0000117 "PlanAndPlannedProcess Branch" ;
+                obo:IAO_0000119 "http://www.holah.karoo.net/experimentaldesigns.htm" ;
+                rdfs:label "repeated measure design" .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0500003
+obo:OBI_0500003 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0500002 ;
+                obo:IAO_0000111 "cross over design" ;
+                obo:IAO_0000112 "PMID: 17601993-Objective: HIV-infected patients with lipodystrophy (HIV-lipodystrophy) are insulin resistant and have elevated plasma free fatty acid (FFA) concentrations. We aimed to explore the mechanisms underlying FFA-induced insulin resistance in patients with HIV-lipodystrophy. Research Design and Methods: Using a randomized placebo-controlled cross-over design, we studied the effects of an overnight acipimox-induced suppression of FFA on glucose and FFA metabolism by using stable isotope labelled tracer techniques during basal conditions and a two-stage euglycemic, hyperinsulinemic clamp (20 mU insulin/m(2)/min; 50 mU insulin/m(2)/min) in nine patients with nondiabetic HIV-lipodystrophy. All patients received antiretroviral therapy. Biopsies from the vastus lateralis muscle were obtained during each stage of the clamp. Results: Acipimox treatment reduced basal FFA rate of appearance by 68.9% (52.6%-79.5%) and decreased plasma FFA concentration by 51.6 % (42.0%-58.9%), (both, P < 0.0001). Endogenous glucose production was not influenced by acipimox. During the clamp the increase in glucose-uptake was significantly greater after acipimox treatment compared to placebo (acipimox: 26.85 (18.09-39.86) vs placebo: 20.30 (13.67-30.13) mumol/kg/min; P < 0.01). Insulin increased phosphorylation of Akt (Thr(308)) and GSK-3beta (Ser(9)), decreased phosphorylation of glycogen synthase (GS) site 3a+b and increased GS-activity (I-form) in skeletal muscle (P < 0.01). Acipimox decreased phosphorylation of GS (site 3a+b) (P < 0.02) and increased GS-activity (P < 0.01) in muscle. Conclusion: The present study provides direct evidence that suppression of lipolysis in patients with HIV-lipodystrophy improves insulin-stimulated peripheral glucose-uptake. The increased glucose-uptake may in part be explained by increased dephosphorylation of GS (site 3a+b) resulting in increased GS activity." ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "a repeated measure design which ensures that experimental units receive, in sequence, the treatment (or the control), and then, after a specified time interval (aka *wash-out periods*), switch to the control (or treatment). In this design, subjects (patients in human context) serve as their own controls, and randomization may be used to determine the ordering which a subject receives the treatment and control" ;
+                obo:IAO_0000117 "Philippe Rocca-Serra" ;
+                obo:IAO_0000119 "(source: http://www.sbu.se/Filer/Content0/publikationer/1/literaturesearching_1993/glossary.html)" ;
+                rdfs:label "cross over design" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0500005
+obo:OBI_0500005 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0500000 ;
+                obo:IAO_0000111 "matched pairs design" ;
+                obo:IAO_0000112 "PMID: 17288613-BSTRACT: BACKGROUND: Physicians in Canadian emergency departments (EDs) annually treat 185,000 alert and stable trauma victims who are at risk for cervical spine (C-spine) injury. However, only 0.9% of these patients have suffered a cervical spine fracture. Current use of radiography is not efficient. The Canadian C-Spine Rule is designed to allow physicians to be more selective and accurate in ordering C-spine radiography, and to rapidly clear the C-spine without the need for radiography in many patients. The goal of this phase III study is to evaluate the effectiveness of an active strategy to implement the Canadian C-Spine Rule into physician practice. Specific objectives are to: 1) determine clinical impact, 2) determine sustainability, 3) evaluate performance, and 4) conduct an economic evaluation. METHODS: We propose a matched-pair cluster design study that compares outcomes during three consecutive 12-months before, after, and decay periods at six pairs of intervention and control sites. These 12 hospital ED sites will be stratified as teaching or community hospitals, matched according to baseline C-spine radiography ordering rates, and then allocated within each pair to either intervention or control groups. During the after period at the intervention sites, simple and inexpensive strategies will be employed to actively implement the Canadian C-Spine Rule. The following outcomes will be assessed: 1) measures of clinical impact, 2) performance of the Canadian C-Spine Rule, and 3) economic measures. During the 12-month decay period, implementation strategies will continue, allowing us to evaluate the sustainability of the effect. We estimate a sample size of 4,800 patients in each period in order to have adequate power to evaluate the main outcomes. DISCUSSION: Phase I successfully derived the Canadian C-Spine Rule and phase II confirmed the accuracy and safety of the rule, hence, the potential for physicians to improve care. What remains unknown is the actual change in clinical behaviors that can be affected by implementation of the Canadian C-Spine Rule, and whether implementation can be achieved with simple and inexpensive measures. We believe that the Canadian C-Spine Rule has the potential to significantly reduce health care costs and improve the efficiency of patient flow in busy Canadian EDs." ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "A matched pair design is a study design which use groups of individuals associated (hence matched) to each other based on a set of criteria, one member going to one treatment, the other member receiving the other treatment." ;
+                obo:IAO_0000117 "Philippe Rocca-Serra" ;
+                obo:IAO_0000119 "http://www.holah.karoo.net/experimentaldesigns.htm" ;
+                rdfs:label "matched pairs design" .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0500006
+obo:OBI_0500006 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0500000 ;
+                obo:IAO_0000111 "parallel group design" ;
+                obo:IAO_0000112 "PMID: 17408389-Purpose: Proliferative vitreoretinopathy (PVR) is the most important reason for blindness following retinal detachment. Presently, vitreous tamponades such as gas or silicone oil cannot contact the lower part of the retina. A heavier-than-water tamponade displaces the inflammatory and PVR-stimulating environment from the inferior area of the retina. The Heavy Silicone Oil versus Standard Silicone Oil Study (HSO Study) is designed to answer the question of whether a heavier-than-water tamponade improves the prognosis of eyes with PVR of the lower retina. Methods: The HSO Study is a multicentre, randomized, prospective controlled clinical trial comparing two endotamponades within a two-arm parallel group design. Patients with inferiorly and posteriorly located PVR are randomized to either heavy silicone oil or standard silicone oil as a tamponading agent. Three hundred and fifty consecutive patients are recruited per group. After intraoperative re-attachment, patients are randomized to either standard silicone oil (1000 cSt or 5000 cSt) or Densiron((R)) as a tamponading agent. The main endpoint criteria are complete retinal attachment at 12 months and change of visual acuity (VA) 12 months postoperatively compared with the preoperative VA. Secondary endpoints include complete retinal attachment before endotamponade removal, quality of life analysis and the number of retina affecting re-operation within 1 year of follow-up. Results: The design and early recruitment phase of the study are described. Conclusions: The results of this study will uncover whether or not heavy silicone oil improves the prognosis of eyes with PVR." ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "A parallel group design or independent measure design is a study design which uses unique experimental unit each experimental group, in other word no two individuals are shared between experimental groups, hence also known as parallel group design. Subjects of a treatment group receive a unique combination of independent variable values making up a treatment" ;
+                obo:IAO_0000117 "Philippe Rocca-Serra" ;
+                obo:IAO_0000118 "independent measure design" ;
+                obo:IAO_0000119 "http://www.holah.karoo.net/experimentaldesigns.htm" ;
+                rdfs:label "parallel group design" .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0500007
+obo:OBI_0500007 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000115 ;
+                obo:IAO_0000111 "randomized complete block design" ;
+                obo:IAO_0000112 "http://www.stats.gla.ac.uk/steps/glossary/anova.html,(A researcher is carrying out a study of the effectiveness of four different skin creams for the treatment of a certain skin disease. He has eighty subjects and plans to divide them into 4 treatment groups of twenty subjects each. Using a randomised blocks& design, the subjects are assessed and put in blocks of four according to how severe their skin condition is; the four most severe cases are the first block, the next four most severe cases are the second block, and so on to the twentieth block. The four &members of each block are then randomly assigned, one to each of the four treatment groups. http://www.stats.gla.ac.uk/steps/glossary/anova.html#rbd))" ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "A randomized complete block design is_a study design which assigns randomly treatments to block. The number of units per block equals the number of treatment so each block receives each treatment exactly once (hence the qualifier 'complete'). The design was originally devised from field trials used in agronomy and agriculture. The analysis assumes that there is no interaction between block and treatment. The method was then used in other settings So The randomised complete block design is a design in which the subjects are matched according to a variable which the experimenter wishes to control. The subjects are put into groups (blocks) of the same size as the number of treatments. The members of each block are then randomly assigned to different treatment groups." ;
+                obo:IAO_0000117 "Philippe Rocca-Serra" ;
+                obo:IAO_0000119 "http://www.tufts.edu/~gdallal/ranblock.htm" ;
+                rdfs:label "randomized complete block design" .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0500008
+obo:OBI_0500008 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0500014 ;
+                obo:IAO_0000111 "balanced incomplete block design" ;
+                obo:IAO_0000112 "PMID: 7622388.Health Educ Q. 1995 May;22(2):201-10.Balanced incomplete block design: description, case study, and implications for practice." ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "balanced incomplete block design is a kind of factorial design where all treatment pairs occur together within a block an equal number ?? times. ??ii' is the number of times treatment i occurs with i'" ;
+                obo:IAO_0000117 "Philippe Rocca-Serra" ;
+                obo:IAO_0000119 "http://en.wikipedia.org/wiki/Block_design and http://www.stat.psu.edu/~jglenn/stat503/05_factorial/02_factorial_IBD.html" ;
+                rdfs:label "balanced incomplete block design" .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0500009
+obo:OBI_0500009 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0500000 ;
+                obo:IAO_0000111 "loop design" ;
+                obo:IAO_0000112 "PMID: 12933549" ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "A loop experiment design is where labeled extracts are compared in consecutive pairs. synonym: circular design" ;
+                obo:IAO_0000117 "Philippe Rocca-Serra on behalf of MO" ;
+                obo:IAO_0000119 "MO_912" ;
+                rdfs:label "loop design" .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0500010
+obo:OBI_0500010 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0500000 ;
+                obo:IAO_0000111 "reference design" ;
+                obo:IAO_0000112 "PMID: 12933549" ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "A reference experiment design type is where all samples are compared to a common reference." ;
+                obo:IAO_0000117 "Philippe Rocca-Serra on behalf of MO" ;
+                obo:IAO_0000119 "MO_699" ;
+                rdfs:label "reference design" .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0500014
+obo:OBI_0500014 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0500000 ;
+                obo:IAO_0000111 "factorial design" ;
+                obo:IAO_0000112 "PMID: 17582121-Our objective was to examine the effects of dietary cation-anion difference (DCAD) with different concentrations of dietary crude protein (CP) on performance and acid-base status in early lactation cows. Six lactating Holstein cows averaging 44 d in milk were used in a 6 x 6 Latin square design with a 2 x 3 factorial arrangement of treatments: DCAD of -3, 22, or 47 milliequivalents (Na + K - Cl - S)/100 g of dry matter (DM), and 16 or 19% CP on a DM basis. Linear increases with DCAD occurred in DM intake, milk fat percentage, 4% fat-corrected milk production, milk true protein, milk lactose, and milk solids-not-fat. Milk production itself was unaffected by DCAD. Jugular venous blood pH, base excess and HCO3(-) concentration, and urine pH increased, but jugular venous blood Cl- concentration, urine titratable acidity, and net acid excretion decreased linearly with increasing DCAD. An elevated ratio of coccygeal venous plasma essential AA to nonessential AA with increasing DCAD indicated that N metabolism in the rumen was affected, probably resulting in more microbial protein flowing to the small intestine. Cows fed 16% CP had lower urea N in milk than cows fed 19% CP; the same was true for urea N in coccygeal venous plasma and urine. Dry matter intake, milk production, milk composition, and acid-base status did not differ between the 16 and 19% CP treatments. It was concluded that DCAD affected DM intake and performance of dairy cows in early lactation. Feeding 16% dietary CP to cows in early lactation, compared with 19% CP, maintained lactation performance while reducing urea N excretion in milk and urine." ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "factorial design is_a study design which is used to evaluate two or more factors simultaneously. The treatments are combinations of levels of the factors. The advantages of factorial designs over one-factor-at-a-time experiments is that they are more efficient and they allow interactions to be detected. In statistics, a factorial design experiment is an experiment whose design consists of two or more factors, each with discrete possible values or levels, and whose experimental units take on all possible combinations of these levels across all such factors. Such an experiment allows studying the effect of each factor on the response variable, as well as the effects of interactions between factors on the response variable." ;
+                obo:IAO_0000117 "Philippe Rocca-Serra" ;
+                obo:IAO_0000119 "http://www.stats.gla.ac.uk/steps/glossary/anova.html#facdes And from wikipedia (01/03/2007): http://en.wikipedia.org/wiki/Factorial_experiment)" ;
+                rdfs:label "factorial design" .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0500018
+obo:OBI_0500018 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0500000 ;
+                obo:IAO_0000111 "replicate design" ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "A replicate experimental design type is where a series of replicates are performed to evaluate reproducibility or as a pilot study to determine the appropriate number of replicates for a subsequent experiments." ;
+                obo:IAO_0000117 "Philippe Rocca-Serra on behalf of MO" ;
+                obo:IAO_0000119 "MO_885" ;
+                rdfs:label "replicate design" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0500020
+obo:OBI_0500020 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0500000 ;
+                obo:IAO_0000111 "time series design" ;
+                obo:IAO_0000112 "PMID: 14744830-Microarrays are powerful tools for surveying the expression levels of many thousands of genes simultaneously. They belong to the new genomics technologies which have important applications in the biological, agricultural and pharmaceutical sciences. There are myriad sources of uncertainty in microarray experiments, and rigorous experimental design is essential for fully realizing the potential of these valuable resources. Two questions frequently asked by biologists on the brink of conducting cDNA or two-colour, spotted microarray experiments are 'Which mRNA samples should be competitively hybridized together on the same slide?' and 'How many times should each slide be replicated?' Early experience has shown that whilst the field of classical experimental design has much to offer this emerging multi-disciplinary area, new approaches which accommodate features specific to the microarray context are needed. In this paper, we propose optimal designs for factorial and time course experiments, which are special designs arising quite frequently in microarray experimentation. Our criterion for optimality is statistical efficiency based on a new notion of admissible designs; our approach enables efficient designs to be selected subject to the information available on the effects of most interest to biologists, the number of arrays available for the experiment, and other resource or practical constraints, including limitations on the amount of mRNA probe. We show that our designs are superior to both the popular reference designs, which are highly inefficient, and to designs incorporating all possible direct pairwise comparisons. Moreover, our proposed designs represent a substantial practical improvement over classical experimental designs which work in terms of standard interactions and main effects. The latter do not provide a basis for meaningful inference on the effects of most interest to biologists, nor make the most efficient use of valuable and limited resources." ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "Groups of assays that are related as part of a time series." ;
+                obo:IAO_0000117 "Philippe Rocca-Serra on behalf of MO" ;
+                obo:IAO_0000119 "MO_887" ;
+                rdfs:label "time series design" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0500022
+obo:OBI_0500022 rdf:type owl:Class ;
+                rdfs:subClassOf obo:IAO_0000055 ;
+                obo:IAO_0000111 "stopping rule"@en ;
+                obo:IAO_0000112 "PMID: 17591081-BACKGROUND/AIMS: To investigate the viral kinetics of Chinese CHC patients received pegylated interferon plus ribavirin and examine the impact of HCV genotypes and severity of liver disease. METHODOLOGY: 65 treatment-naove CHC patients who finished a 24-week therapy with peginterferon (alpha-2b (1.5 mcg/kg/week) plus ribavirin (1000-1200 mg /day) and 24 weeks of follow-up were enrolled. Hepatic fibrosis was graded by the METAVIR scoring system. Serum quantitative HCV RNA was determined by Versant HCV RNA 3.0 assay (Bayer Inc.). RESULTS: Genotype non-1 patients responded quickly and a higher percentage of them achieved undetectable HCV RNA (< 615 IU/mL) at week 4 compared with genotype 1 patients (93% vs. 69%, p = 0.018). Degree of hepatic fibrosis significantly affected end-of-treatment and sustained response (SVR). For patients who did not achieve early virological response (EVR), the negative predictive value for SVR was 100%. In genotype 1 patients, undetectable HCV RNA by week 4 was a good marker to predict treatment response, with a positive predictive value of 84% and a negative predictive value of 82%. CONCLUSIONS: EVR can be applied to Chinese patients as an early stopping rule. A 24-week duration of pegylated IFN/ribavirin might be adequate for genotype 1 patients who rapidly responded to therapy."@en ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "a stopping rule (criterion) is_a *rule* which causes a *stopping process* to happen"@en ;
+                obo:IAO_0000117 "PRS"@en ;
+                obo:IAO_0000119 "PRS"@en ;
+                rdfs:label "stopping rule"@en .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0500023
+obo:OBI_0500023 rdf:type owl:Class ;
+                rdfs:subClassOf obo:IAO_0000055 ;
+                obo:IAO_0000111 "compliance rule"@en ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "a compliance rule is a rule which ensures a compliance process occurs"@en ;
+                obo:IAO_0000117 "PRS"@en ;
+                obo:IAO_0000119 "PRS"@en ;
+                rdfs:label "compliance rule"@en .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0500024
+obo:OBI_0500024 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0500023 ;
+                obo:IAO_0000111 "standard compliance rule"@en ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "a  standard compliance rule is a compliance rule which defines conformity to a representation standard"@en ;
+                obo:IAO_0000117 "PRS"@en ;
+                obo:IAO_0000119 "PRS"@en ;
+                rdfs:label "standard compliance rule"@en .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0500025
+obo:OBI_0500025 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0500024 ;
+                obo:IAO_0000111 "ethical standard compliance rule"@en ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "an ethical standard compliance rule is_a *compliance rule* which enable a  *ethical compliance process* to occur"@en ;
+                obo:IAO_0000117 "PRS"@en ;
+                obo:IAO_0000119 "PRS"@en ;
+                rdfs:label "ethical standard compliance rule"@en .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0500026
+obo:OBI_0500026 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0001755 ;
+                obo:IAO_0000111 "eligibility criterion"@en ;
+                obo:IAO_0000112 "PMID: 17579629 -Eligibility criteria included: untreated ED-SCLC; age >/=70 and performance status 0-2, or age <70 and PS 3."@en ;
+                obo:IAO_0000114 obo:IAO_0000122 ;
+                obo:IAO_0000115 """an eligibility criterion (rule) is_a selection criterion which 
+defines and states the requirements (positive or negative) for an entity to be considered as suitable for a given task or participation in a process."""@en ;
+                obo:IAO_0000117 "Person: Philippe Rocca-Serra"@en ;
+                obo:IAO_0000118 "eligibility rule"@en ;
+                obo:IAO_0000119 "Adapted from Clinical Research Glossary Version 4.0 CDICS glossary group"@en ;
+                rdfs:label "eligibility criterion"@en .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0500027
+obo:OBI_0500027 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0500026 ;
+                obo:IAO_0000111 "inclusion criterion"@en ;
+                obo:IAO_0000112 "PMID: 23979341-The major inclusion criterion was patients in whom severe cerebral embolism was diagnosed at age 75 or younger (more than 9 in the NIHSS score on day 7 after the onset of stroke) ."@en ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "an inclusion criterion (rule) is_a *eligibility criterion*  which defines and states a condition which, if met, makes an entity suitable for a given task or participation in a given process. For instance, in a study protocol, inclusion criteria indicate the conditions that prospective subjects MUST meet to be eligible for participation in a study."@en ;
+                obo:IAO_0000117 "Person: Philippe Rocca-Serra"@en ;
+                obo:IAO_0000118 "inclusion condition"@en ,
+                                "inclusion rule"@en ;
+                obo:IAO_0000119 "Adapted from Clinical Research Glossary Version 4.0 CDICS glossary group"@en ;
+                rdfs:label "inclusion criterion"@en .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0500028
+obo:OBI_0500028 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0500026 ;
+                obo:IAO_0000111 "exclusion rule"@en ;
+                obo:IAO_0000112 "PMID: 17600285-Exclusion criteria included the use of any topical ophthalmic or topical oral medication and/or history of ocular or oral surgery within the past six months."@en ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "an exclusion criterion (rule) is_a *eligibility criterion*  which defines and states a condition which, if met, makes an entity unsuitable for a given task or participation in a given process. For instance, in a study protocol, exclusion criteria indicate the conditions that prospective subjects SHOULD NOT meet to be eligible for participation in a study"@en ;
+                obo:IAO_0000117 "Person: Philippe Rocca-Serra"@en ;
+                obo:IAO_0000119 "Adapted from Clinical Research Glossary Version 4.0 CDICS glossary group"@en ;
+                rdfs:label "exclusion criterion"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0500022
+obo:OBI_0500022 rdf:type owl:Class ;
+                rdfs:subClassOf obo:IAO_0000055 ;
+                obo:IAO_0000111 "stopping rule"@en ;
+                obo:IAO_0000112 "PMID: 17591081-BACKGROUND/AIMS: To investigate the viral kinetics of Chinese CHC patients received pegylated interferon plus ribavirin and examine the impact of HCV genotypes and severity of liver disease. METHODOLOGY: 65 treatment-naove CHC patients who finished a 24-week therapy with peginterferon (alpha-2b (1.5 mcg/kg/week) plus ribavirin (1000-1200 mg /day) and 24 weeks of follow-up were enrolled. Hepatic fibrosis was graded by the METAVIR scoring system. Serum quantitative HCV RNA was determined by Versant HCV RNA 3.0 assay (Bayer Inc.). RESULTS: Genotype non-1 patients responded quickly and a higher percentage of them achieved undetectable HCV RNA (< 615 IU/mL) at week 4 compared with genotype 1 patients (93% vs. 69%, p = 0.018). Degree of hepatic fibrosis significantly affected end-of-treatment and sustained response (SVR). For patients who did not achieve early virological response (EVR), the negative predictive value for SVR was 100%. In genotype 1 patients, undetectable HCV RNA by week 4 was a good marker to predict treatment response, with a positive predictive value of 84% and a negative predictive value of 82%. CONCLUSIONS: EVR can be applied to Chinese patients as an early stopping rule. A 24-week duration of pegylated IFN/ribavirin might be adequate for genotype 1 patients who rapidly responded to therapy."@en ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "a stopping rule (criterion) is_a *rule* which causes a *stopping process* to happen"@en ;
+                obo:IAO_0000117 "PRS"@en ;
+                obo:IAO_0000119 "PRS"@en ;
+                rdfs:label "stopping rule"@en .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0500023
+obo:OBI_0500023 rdf:type owl:Class ;
+                rdfs:subClassOf obo:IAO_0000055 ;
+                obo:IAO_0000111 "compliance rule"@en ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "a compliance rule is a rule which ensures a compliance process occurs"@en ;
+                obo:IAO_0000117 "PRS"@en ;
+                obo:IAO_0000119 "PRS"@en ;
+                rdfs:label "compliance rule"@en .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0500024
+obo:OBI_0500024 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0500023 ;
+                obo:IAO_0000111 "standard compliance rule"@en ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "a  standard compliance rule is a compliance rule which defines conformity to a representation standard"@en ;
+                obo:IAO_0000117 "PRS"@en ;
+                obo:IAO_0000119 "PRS"@en ;
+                rdfs:label "standard compliance rule"@en .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0500025
+obo:OBI_0500025 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0500024 ;
+                obo:IAO_0000111 "ethical standard compliance rule"@en ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "an ethical standard compliance rule is_a *compliance rule* which enable a  *ethical compliance process* to occur"@en ;
+                obo:IAO_0000117 "PRS"@en ;
+                obo:IAO_0000119 "PRS"@en ;
+                rdfs:label "ethical standard compliance rule"@en .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0500026
+obo:OBI_0500026 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0001755 ;
+                obo:IAO_0000111 "eligibility criterion"@en ;
+                obo:IAO_0000112 "PMID: 17579629 -Eligibility criteria included: untreated ED-SCLC; age >/=70 and performance status 0-2, or age <70 and PS 3."@en ;
+                obo:IAO_0000114 obo:IAO_0000122 ;
+                obo:IAO_0000115 """an eligibility criterion (rule) is_a selection criterion which 
+defines and states the requirements (positive or negative) for an entity to be considered as suitable for a given task or participation in a process."""@en ;
+                obo:IAO_0000117 "Person: Philippe Rocca-Serra"@en ;
+                obo:IAO_0000118 "eligibility rule"@en ;
+                obo:IAO_0000119 "Adapted from Clinical Research Glossary Version 4.0 CDICS glossary group"@en ;
+                rdfs:label "eligibility criterion"@en .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0500027
+obo:OBI_0500027 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0500026 ;
+                obo:IAO_0000111 "inclusion criterion"@en ;
+                obo:IAO_0000112 "PMID: 23979341-The major inclusion criterion was patients in whom severe cerebral embolism was diagnosed at age 75 or younger (more than 9 in the NIHSS score on day 7 after the onset of stroke) ."@en ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "an inclusion criterion (rule) is_a *eligibility criterion*  which defines and states a condition which, if met, makes an entity suitable for a given task or participation in a given process. For instance, in a study protocol, inclusion criteria indicate the conditions that prospective subjects MUST meet to be eligible for participation in a study."@en ;
+                obo:IAO_0000117 "Person: Philippe Rocca-Serra"@en ;
+                obo:IAO_0000118 "inclusion condition"@en ,
+                                "inclusion rule"@en ;
+                obo:IAO_0000119 "Adapted from Clinical Research Glossary Version 4.0 CDICS glossary group"@en ;
+                rdfs:label "inclusion criterion"@en .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0500028
+obo:OBI_0500028 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0500026 ;
+                obo:IAO_0000111 "exclusion rule"@en ;
+                obo:IAO_0000112 "PMID: 17600285-Exclusion criteria included the use of any topical ophthalmic or topical oral medication and/or history of ocular or oral surgery within the past six months."@en ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "an exclusion criterion (rule) is_a *eligibility criterion*  which defines and states a condition which, if met, makes an entity unsuitable for a given task or participation in a given process. For instance, in a study protocol, exclusion criteria indicate the conditions that prospective subjects SHOULD NOT meet to be eligible for participation in a study"@en ;
+                obo:IAO_0000117 "Person: Philippe Rocca-Serra"@en ;
+                obo:IAO_0000119 "Adapted from Clinical Research Glossary Version 4.0 CDICS glossary group"@en ;
+                rdfs:label "exclusion criterion"@en .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0600004
+obo:OBI_0600004 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0001928 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000051 ;
+                                  owl:someValuesFrom obo:OBI_0000810
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000055 ;
+                                  owl:someValuesFrom [ rdf:type owl:Restriction ;
+                                                       owl:onProperty obo:RO_0000059 ;
+                                                       owl:someValuesFrom obo:OBI_0500026
+                                                     ]
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000293 ;
+                                  owl:someValuesFrom [ owl:intersectionOf ( obo:OBI_0000181
+                                                                            [ rdf:type owl:Restriction ;
+                                                                              owl:onProperty obo:BFO_0000051 ;
+                                                                              owl:someValuesFrom obo:NCBITaxon_9606
+                                                                            ]
+                                                                          ) ;
+                                                       rdf:type owl:Class
+                                                     ]
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000299 ;
+                                  owl:someValuesFrom [ owl:intersectionOf ( [ owl:intersectionOf ( obo:OBI_0000181
+                                                                                                   [ rdf:type owl:Restriction ;
+                                                                                                     owl:onProperty obo:BFO_0000051 ;
+                                                                                                     owl:someValuesFrom obo:NCBITaxon_9606
+                                                                                                   ]
+                                                                                                 ) ;
+                                                                              rdf:type owl:Class
+                                                                            ]
+                                                                            [ rdf:type owl:Restriction ;
+                                                                              owl:onProperty obo:RO_0000087 ;
+                                                                              owl:someValuesFrom obo:OBI_0000097
+                                                                            ]
+                                                                          ) ;
+                                                       rdf:type owl:Class
+                                                     ]
+                                ] ;
+                obo:IAO_0000111 "human subject enrollment"@en ;
+                obo:IAO_0000112 "enlisting familiy members of HIV patients into a study"@en ;
+                obo:IAO_0000114 obo:IAO_0000122 ;
+                obo:IAO_0000115 "A planned process with the objective to obtain a population of human subjects to participate in an investigation by determining eligibility of subjects and obtaining informed consent."@en ;
+                obo:IAO_0000116 "As with group assignment, should the specified output here be an organism which bears a role" ;
+                obo:IAO_0000117 "Bjoern Peters"@en ;
+                obo:IAO_0000119 "IEDB"@en ;
+                obo:IAO_0000232 "criteria come from plan / clinical trial branch"@en ;
+                rdfs:label "human subject enrollment"@en .
+		
+
+
+###  http://purl.obolibrary.org/obo/OBI_0600005
+obo:OBI_0600005 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000659 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000293 ;
+                                  owl:someValuesFrom obo:OBI_0100026
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000299 ;
+                                  owl:someValuesFrom obo:OBI_0100051
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000417 ;
+                                  owl:someValuesFrom obo:OBI_0000684
+                                ] ;
+                obo:IAO_0000111 "collecting specimen from organism"@en ;
+                obo:IAO_0000112 "taking a sputum sample from a cancer patient, taking the spleen from a killed mouse, collecting a urine sample from a patient"@en ;
+                obo:IAO_0000114 obo:IAO_0000122 ;
+                obo:IAO_0000115 "a process with the objective to obtain a material entity that was part of an organism for potential future use in an investigation"@en ;
+                obo:IAO_0000117 "PERSON:Bjoern Peters"@en ;
+                obo:IAO_0000119 "IEDB"@en ;
+                rdfs:label "collecting specimen from organism"@en .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0600007
+obo:OBI_0600007 rdf:type owl:Class ;
+                owl:equivalentClass [ owl:intersectionOf ( [ rdf:type owl:Restriction ;
+                                                             owl:onProperty obo:BFO_0000055 ;
+                                                             owl:someValuesFrom obo:OBI_0000319
+                                                           ]
+                                                           [ rdf:type owl:Restriction ;
+                                                             owl:onProperty obo:BFO_0000055 ;
+                                                             owl:someValuesFrom [ owl:intersectionOf ( obo:OBI_0000444
+                                                                                                       [ rdf:type owl:Restriction ;
+                                                                                                         owl:onProperty obo:RO_0000081 ;
+                                                                                                         owl:someValuesFrom [ rdf:type owl:Class ;
+                                                                                                                              owl:unionOf ( obo:OBI_0100026
+                                                                                                                                            obo:UBERON_0000465
+                                                                                                                                          )
+                                                                                                                            ]
+                                                                                                       ]
+                                                                                                     ) ;
+                                                                                  rdf:type owl:Class
+                                                                                ]
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf obo:OBI_0000274 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000293 ;
+                                  owl:someValuesFrom obo:OBI_0100026
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000299 ;
+                                  owl:someValuesFrom obo:OBI_0100026
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000417 ;
+                                  owl:someValuesFrom obo:OBI_0000434
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000299 ;
+                                  owl:maxCardinality "1"^^xsd:nonNegativeInteger
+                                ] ;
+                obo:IAO_0000111 "administering substance in vivo"@en ;
+                obo:IAO_0000112 "Balb/c mice received an intracameral or subconjunctival injection of trinitrophenylated spleen cells" ,
+                                "injecting mice with 10 ug morphine intranasally, a patient taking two pills of 1 mg aspirin orally"@en ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "A process by which a substance is intentionally given to an organism resulting in exposure of the organism to that substance." ;
+                obo:IAO_0000116 "2009-11-10. Tracker: https://sourceforge.net/tracker/?func=detail&aid=2893050&group_id=177891&atid=886178" ,
+                                "Different routes and means of administration should go as children underneath this"@en ,
+                                """Update the definition based on the discussion. Details see the tracker:
+https://sourceforge.net/p/obi/obi-terms/738/""" ,
+                                "needs roles such as perturber and perturbee (children of input role). Perturb is too strong. Host might be the name for one role. Others considered: Doner, Donated, Acceptor."@en ;
+                obo:IAO_0000117 "Bjoern Peters"@en ,
+                                "Person:Bjoern Peters" ;
+                obo:IAO_0000119 "IEDB"@en ;
+                rdfs:label "administering substance in vivo"@en .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0600008
+obo:OBI_0600008 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0001928 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000055 ;
+                                  owl:someValuesFrom [ rdf:type owl:Restriction ;
+                                                       owl:onProperty obo:RO_0000059 ;
+                                                       owl:someValuesFrom obo:OBI_0001755
+                                                     ]
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000299 ;
+                                  owl:someValuesFrom [ rdf:type owl:Class ;
+                                                       owl:unionOf ( obo:BFO_0000040
+                                                                     obo:IAO_0000030
+                                                                   )
+                                                     ]
+                                ] ;
+                obo:IAO_0000111 "acquisition"@en ;
+                obo:IAO_0000112 "Downloading a 3D structure from the PDB. Purchasing antibodies from sigma." ;
+                obo:IAO_0000114 obo:IAO_0000122 ;
+                obo:IAO_0000115 "the planned process of gaining possession of a continuant."@en ;
+                obo:IAO_0000116 "5/31/2012 - OBI workshop: This process is not implying ownership of the material / information." ,
+                                """Following OBI call November 2012,5th:
+addition of a restriction to acquisition class to capture the need of having selection criteria
+Relates to the creation of a class 'selection rule'"""@en ;
+                obo:IAO_0000117 "Bjoern Peters"@en ;
+                obo:IAO_0000119 "IEDB"@en ;
+                obo:IAO_0000232 "This needs to be fleshed out and logical definitions added that will allow to place the children terms automatically under acquisition"@en ;
+                rdfs:label "acquisition"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0600010
+obo:OBI_0600010 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0600008 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000299 ;
+                                  owl:someValuesFrom obo:BFO_0000040
+                                ] ;
+                obo:IAO_0000111 "material acquisition"@en ;
+                obo:IAO_0000112 "Acquiring 50 C57BL/6 mice bred in the animal facility of the institute as a service to investigators. Purchasing 1 mg of peptides synthesized by Mimotopes at 80% purity. Getting a gift of purified CD4+ specific antibodies presented by Stephen Schoenberger at LIAI."@en ;
+                obo:IAO_0000114 obo:IAO_0000122 ;
+                obo:IAO_0000115 "An acquisition in which possession of a material entity is gained."@en ;
+                obo:IAO_0000116 "The assumption is that the object already exists in its current state, e.g, an available mouse strain purchased from the Jackson Lab, this is the differentia from specimen creation" ,
+                                "This excludes processes that create or change materials, such as material transformations." ;
+                obo:IAO_0000117 "Bjoern Peters, Alan Ruttenberg, Helen Parkinson"@en ;
+                obo:IAO_0000118 "material procurement" ;
+                obo:IAO_0000119 "IEDB"@en ;
+                rdfs:label "material acquisition"@en .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0600013
+obo:OBI_0600013 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0600008 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000299 ;
+                                  owl:someValuesFrom obo:IAO_0000030
+                                ] ;
+                obo:IAO_0000111 "information acquisition"@en ;
+                obo:IAO_0000112 "Gathering all influenza HA sequences from GenBank, Retrieveing HLA allele frequencies in the North American populations from dbMHC"@en ;
+                obo:IAO_0000114 obo:IAO_0000122 ;
+                obo:IAO_0000115 "An acquisition in which possession of information is gained."@en ;
+                obo:IAO_0000116 "This excludes processes that create or change information, such as assays and data transformations." ;
+                obo:IAO_0000117 "Bjoern Peters"@en ;
+                obo:IAO_0000118 "data collection" ;
+                obo:IAO_0000119 "OBI branch derived"@en ;
+                rdfs:label "information acquisition"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0600015
+obo:OBI_0600015 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000011 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000293 ;
+                                  owl:someValuesFrom obo:OBI_0100026
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000299 ;
+                                  owl:someValuesFrom [ owl:intersectionOf ( obo:BFO_0000023
+                                                                            [ rdf:type owl:Restriction ;
+                                                                              owl:onProperty obo:RO_0000052 ;
+                                                                              owl:someValuesFrom obo:OBI_0100026
+                                                                            ]
+                                                                          ) ;
+                                                       rdf:type owl:Class
+                                                     ]
+                                ] ;
+                obo:IAO_0000111 "group assignment"@en ;
+                obo:IAO_0000112 "Assigning' to be treated with active ingredient role' to an organism during group assignment. The group is those organisms that have the same role in the context of an investigation"@en ;
+                obo:IAO_0000114 obo:IAO_0000122 ;
+                obo:IAO_0000115 "group assignment is a process which has an organism as specified input and during which a role is assigned"@en ;
+                obo:IAO_0000117 "Philippe Rocca-Serra"@en ;
+                obo:IAO_0000118 "cohort assignment" ,
+                                "study assignment" ;
+                obo:IAO_0000119 "OBI Plan"@en ;
+                rdfs:label "group assignment"@en .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0600018
+obo:OBI_0600018 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0600014 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000417 ;
+                                  owl:someValuesFrom obo:OBI_0000678
+                                ] ;
+                obo:IAO_0000111 "material portioning"@en ;
+                obo:IAO_0000112 "pouring 50 mL aliquots of fetal calf serum into conical tubes from a 500 mL stock"@en ;
+                obo:IAO_0000114 obo:IAO_0000123 ;
+                obo:IAO_0000115 "a material processing in which the input substance is partitioned into a number of portions that are similar in composition."@en ;
+                obo:IAO_0000117 "PERSON:Bjoern Peters"@en ;
+                obo:IAO_0000118 "aliquoting"@en ,
+                                "apportioning"@en ;
+                obo:IAO_0000119 "OBI branch derived"@en ;
+                rdfs:label "material portioning"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0600020
+obo:OBI_0600020 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000070 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000051 ;
+                                  owl:someValuesFrom obo:OBI_0000341
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:BFO_0000051 ;
+                                  owl:someValuesFrom [ owl:intersectionOf ( obo:OBI_0000185
+                                                                            obo:OBI_0003368
+                                                                          ) ;
+                                                       rdf:type owl:Class
+                                                     ]
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000299 ;
+                                  owl:someValuesFrom [ rdf:type owl:Restriction ;
+                                                       owl:onProperty obo:IAO_0000136 ;
+                                                       owl:someValuesFrom [ rdf:type owl:Class ;
+                                                                            owl:unionOf ( obo:CL_0000000
+                                                                                          obo:OBI_0100066
+                                                                                        )
+                                                                          ]
+                                                     ]
+                                ] ;
+                obo:IAO_0000111 "histological assay" ;
+                obo:IAO_0000112 "the counting of the number of cells with fluorescent label at their surface to determine the percentage of the population which was activated" ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "An assay that uses visual examination of cells or tissue (or images of them) to make an assessment regarding a quality of the cells or tissue. This assay can include steps of staining, imaging, and judgement." ;
+                obo:IAO_0000117 "Adam Witney" ,
+                                "Helen Parkinson" ;
+                obo:IAO_0000118 "histology" ,
+                                "histopathology" ;
+                obo:IAO_0000119 "OBI branch derived" ;
+                rdfs:label "histological assay" .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_0600021
+obo:OBI_0600021 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0000094 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000293 ;
+                                  owl:someValuesFrom [ owl:intersectionOf ( obo:CL_0000000
+                                                                            [ rdf:type owl:Restriction ;
+                                                                              owl:onProperty obo:RO_0001025 ;
+                                                                              owl:someValuesFrom obo:OBI_0100051
+                                                                            ]
+                                                                          ) ;
+                                                       rdf:type owl:Class
+                                                     ]
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000293 ;
+                                  owl:someValuesFrom [ rdf:type owl:Class ;
+                                                       owl:unionOf ( obo:CHEBI_23367
+                                                                     obo:OBI_0302729
+                                                                   )
+                                                     ]
+                                ] ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000417 ;
+                                  owl:someValuesFrom obo:OBI_0000456
+                                ] ;
+                obo:IAO_0000111 "cell fixation"@en ;
+                obo:IAO_0000112 "http://www.tissuearray.org/CellLinesProtocolforTMA112.pdf; the treatment of CD8+ cells with methanol at -20oC; http://www.ncbi.nlm.nih.gov/sites/entrez?cmd=Retrieve&db=PubMed&amp;list_uids=16080188&dopt=AbstractPlus"@en ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "a protocol application to preserve defined  qualities of cells or tissues (sample) which may otherwise change over time"@en ;
+                obo:IAO_0000116 "should include capturing what qualities are being preserved"@en ;
+                obo:IAO_0000117 "PERSON:Bjoern Peters"@en ;
+                obo:IAO_0000119 "OBI branch derived"@en ;
+                obo:IAO_0000232 "we could generalize this for other input materials"@en ;
+                rdfs:label "cell fixation"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_1110095
+obo:OBI_1110095 rdf:type owl:Class ;
+                rdfs:subClassOf obo:OBI_0600014 ,
+                                [ rdf:type owl:Restriction ;
+                                  owl:onProperty obo:OBI_0000299 ;
+                                  owl:someValuesFrom obo:OBI_0000655
+                                ] ;
+                obo:IAO_0000111 "blood harvesting" ;
+                obo:IAO_0000114 obo:IAO_0000123 ;
+                obo:IAO_0000115 "A material separation where blood is taken from an organism."@en ;
+                obo:IAO_0000117 "IEDB"@en ;
+                obo:IAO_0000119 "IEDB"@en ;
+                rdfs:label "blood harvesting"@en .
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_1110122
+obo:OBI_1110122 rdf:type owl:Class ;
+                rdfs:subClassOf obo:GO_0008150 ;
+                obo:IAO_0000111 "pathologic process" ;
+                obo:IAO_0000114 obo:IAO_0000123 ;
+                obo:IAO_0000115 "abnormal, harmful processes caused by or associated with a disease"@en ;
+                obo:IAO_0000117 "IEDB"@en ;
+                obo:IAO_0000119 "IEDB"@en ;
+                rdfs:label "pathologic process"@en .
+
+
+
+
+###  http://purl.obolibrary.org/obo/OBI_2000013
+obo:OBI_2000013 rdf:type owl:Class ;
+                owl:equivalentClass [ owl:intersectionOf ( [ owl:intersectionOf ( obo:OBI_0100051
+                                                                                  [ rdf:type owl:Restriction ;
+                                                                                    owl:onProperty obo:OBI_0000312 ;
+                                                                                    owl:someValuesFrom obo:OBI_0000659
+                                                                                  ]
+                                                                                  [ rdf:type owl:Restriction ;
+                                                                                    owl:onProperty obo:RO_0001000 ;
+                                                                                    owl:someValuesFrom obo:UBERON_0013755
+                                                                                  ]
+                                                                                ) ;
+                                                             rdf:type owl:Class
+                                                           ]
+                                                           [ owl:intersectionOf ( obo:OBI_0100051
+                                                                                  [ rdf:type owl:Restriction ;
+                                                                                    owl:onProperty obo:OBI_0000312 ;
+                                                                                    owl:someValuesFrom obo:OBI_0600005
+                                                                                  ]
+                                                                                ) ;
+                                                             rdf:type owl:Class
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf obo:OBI_2000009 ;
+                obo:IAO_0000111 "arterial blood specimen" ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A specimen that is derived from some arterial blood" ;
+                obo:IAO_0000117 "Christian Stoeckert ORCID:0000-0002-5714-991X" ,
+                                "Mark A. Miller ORCID:0000-0001-9076-6066" ;
+                obo:IAO_0000119 "Christian Stoeckert ORCID:0000-0002-5714-991X" ,
+                                "Mark A. Miller ORCID:0000-0001-9076-6066" ;
+                rdfs:label "arterial blood specimen" .
+
+
+###  http://purl.obolibrary.org/obo/OBI_2000014
+obo:OBI_2000014 rdf:type owl:Class ;
+                owl:equivalentClass [ owl:intersectionOf ( [ owl:intersectionOf ( obo:OBI_0100051
+                                                                                  [ rdf:type owl:Restriction ;
+                                                                                    owl:onProperty obo:OBI_0000312 ;
+                                                                                    owl:someValuesFrom obo:OBI_0000659
+                                                                                  ]
+                                                                                  [ rdf:type owl:Restriction ;
+                                                                                    owl:onProperty obo:RO_0001000 ;
+                                                                                    owl:someValuesFrom obo:UBERON_0013756
+                                                                                  ]
+                                                                                ) ;
+                                                             rdf:type owl:Class
+                                                           ]
+                                                           [ owl:intersectionOf ( obo:OBI_0100051
+                                                                                  [ rdf:type owl:Restriction ;
+                                                                                    owl:onProperty obo:OBI_0000312 ;
+                                                                                    owl:someValuesFrom obo:OBI_0600005
+                                                                                  ]
+                                                                                ) ;
+                                                             rdf:type owl:Class
+                                                           ]
+                                                         ) ;
+                                      rdf:type owl:Class
+                                    ] ;
+                rdfs:subClassOf obo:OBI_2000009 ;
+                obo:IAO_0000111 "venous blood specimen" ;
+                obo:IAO_0000114 obo:IAO_0000120 ;
+                obo:IAO_0000115 "A specimen that is derived from some venous blood" ;
+                obo:IAO_0000117 "Christian Stoeckert ORCID:0000-0002-5714-991X" ,
+                                "Mark A. Miller ORCID:0000-0001-9076-6066" ;
+                obo:IAO_0000119 "Christian Stoeckert ORCID:0000-0002-5714-991X" ,
+                                "Mark A. Miller ORCID:0000-0001-9076-6066" ;
+                rdfs:label "venous blood specimen" .
+
+
+##  http://purl.obolibrary.org/obo/OGMS_0000015
+obo:OGMS_0000015 rdf:type owl:Class ;
+                 rdfs:subClassOf obo:IAO_0000030 ;
+                 obo:IAO_0000111 "clinical history" ;
+                 obo:IAO_0000115 "A series of statements representing health-relevant qualities of a patient and of a patient's family."@en ;
+                 obo:IAO_0000412 obo:ogms.owl ;
+                 rdfs:label "clinical history" .
+
+
+###  http://purl.obolibrary.org/obo/OGMS_0000023
+obo:OGMS_0000023 rdf:type owl:Class ;
+                 rdfs:subClassOf obo:BFO_0000019 ;
+                 obo:IAO_0000111 "phenotype" ;
+                 obo:IAO_0000115 "A (combination of) quality(ies) of an organism determined by the interaction of its genetic make-up and environment that differentiates specific instances of a species from other instances of the same species."@en ;
+                 obo:IAO_0000412 obo:ogms.owl ;
+                 rdfs:label "phenotype" .
+
+
+###  http://purl.obolibrary.org/obo/OGMS_0000031
+obo:OGMS_0000031 rdf:type owl:Class ;
+                 rdfs:subClassOf obo:BFO_0000016 ;
+                 obo:IAO_0000111 "disease" ;
+                 obo:IAO_0000115 "A disposition (i) to undergo pathological processes that (ii) exists in an organism because of one or more disorders in that organism."@en ;
+                 obo:IAO_0000412 obo:ogms.owl ;
+                 rdfs:label "disease" .
+
+
+##  http://purl.obolibrary.org/obo/OGMS_0000073
+obo:OGMS_0000073 rdf:type owl:Class ;
+                 rdfs:subClassOf obo:IAO_0000027 ;
+                 obo:IAO_0000111 "diagnosis" ;
+                 obo:IAO_0000115 "The representation of a conclusion of a diagnostic process."@en ;
+                 obo:IAO_0000412 obo:ogms.owl ;
+                 rdfs:label "diagnosis" .
+
+
+###  http://purl.obolibrary.org/obo/OGMS_0000090
+obo:OGMS_0000090 rdf:type owl:Class ;
+                 rdfs:subClassOf obo:OBI_0000011 ;
+                 obo:IAO_0000111 "treatment" ;
+                 obo:IAO_0000115 "A planned process whose completion is hypothesized by a health care provider to eliminate, prevent, or alleviate a disorder, the signs and symptoms of a disorder, or a pathological process"@en ;
+                 obo:IAO_0000412 obo:ogms.owl ;
+                 rdfs:label "treatment" .
+
+
+###  http://purl.obolibrary.org/obo/OMIABIS_0000050
+obo:OMIABIS_0000050 rdf:type owl:Class ;
+                    rdfs:subClassOf obo:OBI_0000953 ;
+                    obo:IAO_0000111 "fixed tissue specimen"@en ;
+                    obo:IAO_0000115 "A processed specimen that is the output of a fixation process."@en ;
+                    obo:IAO_0000412 obo:omiabis.owl ;
+                    rdfs:label "fixed tissue specimen"@en .
+
+
+###  http://purl.obolibrary.org/obo/OMIABIS_0000052
+obo:OMIABIS_0000052 rdf:type owl:Class ;
+                    rdfs:subClassOf obo:OMIABIS_0000050 ;
+                    obo:IAO_0000111 "fixed tissue slide specimen"@en ;
+                    obo:IAO_0000115 "A fixed tissue specimen that is placed in a slide."@en ;
+                    obo:IAO_0000412 obo:omiabis.owl ;
+                    rdfs:label "fixed tissue slide specimen"@en .
+
+
+
+##  http://purl.obolibrary.org/obo/PATO_0000011
+obo:PATO_0000011 rdf:type owl:Class ;
+                 rdfs:subClassOf obo:PATO_0000165 ;
+                 obo:IAO_0000111 "age" ;
+                 obo:IAO_0000115 "A time quality inhering in a bearer by virtue of how long the bearer has existed." ;
+                 obo:IAO_0000412 obo:pato.owl ;
+                 rdfs:label "age" .
+
+
+##  http://purl.obolibrary.org/obo/PATO_0000033
+obo:PATO_0000033 rdf:type owl:Class ;
+                 rdfs:subClassOf obo:PATO_0002182 ;
+                 obo:IAO_0000111 "concentration of" ;
+                 obo:IAO_0000115 "A quality inhering in a substance by virtue of the amount of the bearer's there is mixed with another substance." ;
+                 obo:IAO_0000412 obo:pato.owl ;
+                 rdfs:label "concentration of" .
+
+
+###  http://purl.obolibrary.org/obo/PATO_0000047
+obo:PATO_0000047 rdf:type owl:Class ;
+                 rdfs:subClassOf obo:PATO_0001995 ;
+                 obo:IAO_0000111 "biological sex" ;
+                 obo:IAO_0000115 "An organismal quality inhering in a bearer by virtue of the bearer's ability to undergo sexual reproduction in order to differentiate the individuals or types involved." ;
+                 obo:IAO_0000412 obo:pato.owl ;
+                 rdfs:label "biological sex" .
+
+
+
+
+##  http://purl.obolibrary.org/obo/PATO_0000117
+obo:PATO_0000117 rdf:type owl:Class ;
+                 rdfs:subClassOf obo:PATO_0000051 ;
+                 obo:IAO_0000111 "size" ;
+                 obo:IAO_0000115 "A morphology quality inhering in a bearer by virtue of the bearer's physical magnitude." ;
+                 obo:IAO_0000412 obo:pato.owl ;
+                 rdfs:label "size" .
+
+
+###  http://purl.obolibrary.org/obo/PATO_0000122
+obo:PATO_0000122 rdf:type owl:Class ;
+                 rdfs:subClassOf obo:PATO_0000051 ;
+                 obo:IAO_0000111 "length" ;
+                 obo:IAO_0000115 "A 1-D extent quality which is equal to the distance between two points." ;
+                 obo:IAO_0000412 obo:pato.owl ;
+                 rdfs:label "length" .
+
+
+###  http://purl.obolibrary.org/obo/PATO_0000125
+obo:PATO_0000125 rdf:type owl:Class ;
+                 rdfs:subClassOf obo:PATO_0001018 ;
+                 obo:IAO_0000111 "mass" ;
+                 obo:IAO_0000115 "A physical quality that inheres in a bearer by virtue of the proportion of the bearer's amount of matter." ;
+                 obo:IAO_0000412 obo:pato.owl ;
+                 rdfs:label "mass" .
+
+
+###  http://purl.obolibrary.org/obo/PATO_0000140
+obo:PATO_0000140 rdf:type owl:Class ;
+                 rdfs:subClassOf obo:PATO_0001018 ;
+                 obo:IAO_0000111 "position" ;
+                 obo:IAO_0000115 "A spatial quality inhering in a bearer by virtue of the bearer's spatial location relative to other objects in the vicinity." ;
+                 obo:IAO_0000412 obo:pato.owl ;
+                 rdfs:label "position" .
+
+
+###  http://purl.obolibrary.org/obo/PATO_0000141
+obo:PATO_0000141 rdf:type owl:Class ;
+                 rdfs:subClassOf obo:PATO_0000051 ;
+                 obo:IAO_0000111 "structure" ;
+                 obo:IAO_0000115 "A morphology quality inhering in a bearer by virtue of the bearer's relative position, shape, arrangements and connectivity of an organism's various parts; the pattern underlying its form." ;
+                 obo:IAO_0000412 obo:pato.owl ;
+                 rdfs:label "structure" .
+
+
+###  http://purl.obolibrary.org/obo/PATO_0000146
+obo:PATO_0000146 rdf:type owl:Class ;
+                 rdfs:subClassOf obo:PATO_0001018 ;
+                 obo:IAO_0000111 "temperature" ;
+                 obo:IAO_0000115 "A physical quality of the thermal energy of a system." ;
+                 obo:IAO_0000412 obo:pato.owl ;
+                 rdfs:label "temperature" .
+
+
+###  http://purl.obolibrary.org/obo/PATO_0000165
+obo:PATO_0000165 rdf:type owl:Class ;
+                 rdfs:subClassOf obo:PATO_0001018 ;
+                 obo:IAO_0000111 "time" ;
+                 obo:IAO_0000115 "A quality in which events occur in sequence." ;
+                 obo:IAO_0000412 obo:pato.owl ;
+                 rdfs:label "time" .
+
+
+
+##  http://purl.obolibrary.org/obo/PATO_0000186
+obo:PATO_0000186 rdf:type owl:Class ;
+                 rdfs:subClassOf obo:PATO_0001995 ;
+                 obo:IAO_0000111 "behavioral quality" ;
+                 obo:IAO_0000115 "An organismal quality inhering in a bearer by virtue of the bearer's behavior aggregate of the responses or reactions or movements in a given situation." ;
+                 obo:IAO_0000412 obo:pato.owl ;
+                 rdfs:label "behavioral quality" .
+
+
+###  http://purl.obolibrary.org/obo/PATO_0000383
+obo:PATO_0000383 rdf:type owl:Class ;
+                 rdfs:subClassOf obo:PATO_0001894 ;
+                 obo:IAO_0000111 "female" ;
+                 obo:IAO_0000115 "A biological sex quality inhering in an individual or a population that only produces gametes that can be fertilised by male gametes." ;
+                 obo:IAO_0000412 obo:pato.owl ;
+                 rdfs:label "female" .
+
+
+###  http://purl.obolibrary.org/obo/PATO_0000384
+obo:PATO_0000384 rdf:type owl:Class ;
+                 rdfs:subClassOf obo:PATO_0001894 ;
+                 obo:IAO_0000111 "male" ;
+                 obo:IAO_0000115 "A biological sex quality inhering in an individual or a population whose sex organs contain only male gametes." ;
+                 obo:IAO_0000412 obo:pato.owl ;
+                 rdfs:label "male" .
+
+
+###  http://purl.obolibrary.org/obo/PATO_0000918
+obo:PATO_0000918 rdf:type owl:Class ;
+                 rdfs:subClassOf obo:PATO_0001710 ;
+                 obo:IAO_0000111 "volume" ;
+                 obo:IAO_0000115 "A 3-D extent quality inhering in a bearer by virtue of the bearer's amount of 3-dimensional space it occupies." ;
+                 obo:IAO_0000412 obo:pato.owl ;
+                 rdfs:label "volume" .
+
+
+###  http://purl.obolibrary.org/obo/PATO_0001018
+obo:PATO_0001018 rdf:type owl:Class ;
+                 rdfs:subClassOf obo:PATO_0001241 ;
+                 obo:IAO_0000111 "physical quality" ;
+                 obo:IAO_0000115 "A quality of a physical entity that exists through action of continuants at the physical level of organisation in relation to other entities." ;
+                 obo:IAO_0000412 obo:pato.owl ;
+                 rdfs:label "physical quality" .
+
+
+##  http://purl.obolibrary.org/obo/PATO_0001193
+obo:PATO_0001193 rdf:type owl:Class ;
+                 rdfs:subClassOf obo:PATO_0000140 ;
+                 obo:IAO_0000111 "lateral to" ;
+                 obo:IAO_0000115 "A spatial quality inhering in a bearer by virtue of the bearer's being located toward the side relative to another entity." ;
+                 obo:IAO_0000412 obo:pato.owl ;
+                 rdfs:label "lateral to" .
+
+
+###  http://purl.obolibrary.org/obo/PATO_0001196
+obo:PATO_0001196 rdf:type owl:Class ;
+                 rdfs:subClassOf obo:PATO_0000140 ;
+                 obo:IAO_0000111 "ventral to" ;
+                 obo:IAO_0000115 "A spatial quality inhering in a bearer by virtue of the bearer's being located toward the abdomen of an organism relative to another entity." ;
+                 obo:IAO_0000412 obo:pato.owl ;
+                 rdfs:label "ventral to" .
+
+
+###  http://purl.obolibrary.org/obo/PATO_0001233
+obo:PATO_0001233 rdf:type owl:Class ;
+                 rdfs:subClassOf obo:PATO_0000140 ;
+                 obo:IAO_0000111 "dorsal to" ;
+                 obo:IAO_0000115 "A spatial quality inhering in a bearer by virtue of the bearer's being located toward the back or upper surface of an organism relative to another entity." ;
+                 obo:IAO_0000412 obo:pato.owl ;
+                 rdfs:label "dorsal to" .
+
+
+
+##  http://purl.obolibrary.org/obo/PATO_0001338
+obo:PATO_0001338 rdf:type owl:Class ;
+                 rdfs:subClassOf obo:PATO_0002003 ;
+                 obo:IAO_0000111 "mixed sex" ;
+                 obo:IAO_0000115 "A biological sex quality inhering in a population of multiple sexes." ;
+                 obo:IAO_0000412 obo:pato.owl ;
+                 rdfs:label "mixed sex" .
+
+
+##  http://purl.obolibrary.org/obo/PATO_0001340
+obo:PATO_0001340 rdf:type owl:Class ;
+                 rdfs:subClassOf obo:PATO_0001894 ;
+                 obo:IAO_0000111 "hermaphrodite" ;
+                 obo:IAO_0000115 "A biological sex quality inhering in an organism or a population with both male and female sexual organs in one individual." ;
+                 obo:IAO_0000412 obo:pato.owl ;
+                 rdfs:label "hermaphrodite" .
+
+
+##  http://purl.obolibrary.org/obo/PATO_0001546
+obo:PATO_0001546 rdf:type owl:Class ;
+                 rdfs:subClassOf obo:PATO_0002198 ;
+                 obo:IAO_0000111 "quality of a solid" ;
+                 obo:IAO_0000115 "A physical quality inhering in a bearer by virtue of the bearer's exhibiting the physical characteristics of an entity characterized by particles arranged such that their shape and volume are relatively stable." ;
+                 obo:IAO_0000412 obo:pato.owl ;
+                 rdfs:label "quality of a solid" .
+
+
+###  http://purl.obolibrary.org/obo/PATO_0001547
+obo:PATO_0001547 rdf:type owl:Class ;
+                 rdfs:subClassOf obo:PATO_0002198 ;
+                 obo:IAO_0000111 "quality of a gas" ;
+                 obo:IAO_0000115 "A physical quality inhering in a bearer by virtue of the bearer's exhibiting the physical characteristics of an entity consisting of particles that have neither a defined volume nor defined shape." ;
+                 obo:IAO_0000412 obo:pato.owl ;
+                 rdfs:label "quality of a gas" .
+
+
+###  http://purl.obolibrary.org/obo/PATO_0001548
+obo:PATO_0001548 rdf:type owl:Class ;
+                 rdfs:subClassOf obo:PATO_0002198 ;
+                 obo:IAO_0000111 "quality of a liquid" ;
+                 obo:IAO_0000115 "A physical quality inhering in an entity exhibiting the physical characteristics of an amorphous (non-crystalline) form of matter between a gas and a solid that has a definite volume, but no definite shape." ;
+                 obo:IAO_0000412 obo:pato.owl ;
+                 rdfs:label "quality of a liquid" .
+
+
+###  http://purl.obolibrary.org/obo/PATO_0001574
+obo:PATO_0001574 rdf:type owl:Class ;
+                 rdfs:subClassOf obo:PATO_0001906 ;
+                 obo:IAO_0000111 "flow rate" ;
+                 obo:IAO_0000115 "A physical quality inhering in a bearer by virtue of the bearer's motion characteristic." ;
+                 obo:IAO_0000412 obo:pato.owl ;
+                 rdfs:label "flow rate" .
+
+
+###  http://purl.obolibrary.org/obo/PATO_0001632
+obo:PATO_0001632 rdf:type owl:Class ;
+                 rdfs:subClassOf obo:PATO_0000140 ;
+                 obo:IAO_0000111 "anterior to" ;
+                 obo:IAO_0000115 "A spatial quality inhering in a bearer by virtue of the bearer's being located toward the front of an organism relative to another entity." ;
+                 obo:IAO_0000118 "frontal"@en ;
+                 obo:IAO_0000412 obo:pato.owl ;
+                 rdfs:label "anterior to" .
+
+
+###  http://purl.obolibrary.org/obo/PATO_0001710
+obo:PATO_0001710 rdf:type owl:Class ;
+                 rdfs:subClassOf obo:PATO_0000117 ;
+                 obo:IAO_0000111 "3-D extent" ;
+                 obo:IAO_0000115 "A size quality inhering in an bearer by virtue of the bearer's extension in three dimensions." ;
+                 obo:IAO_0000412 obo:pato.owl ;
+                 rdfs:label "3-D extent" .
+
+
+
+##  http://purl.obolibrary.org/obo/PATO_0001739
+obo:PATO_0001739 rdf:type owl:Class ;
+                 rdfs:subClassOf obo:PATO_0001018 ;
+                 obo:IAO_0000111 "radiation quality" ;
+                 obo:IAO_0000115 "A quality that inheres in an bearer by virtue of how that bearer interacts with radiation." ;
+                 obo:IAO_0000412 obo:pato.owl ;
+                 rdfs:label "radiation quality" .
+
+
+###  http://purl.obolibrary.org/obo/PATO_0001740
+obo:PATO_0001740 rdf:type owl:Class ;
+                 rdfs:subClassOf obo:PATO_0001739 ;
+                 obo:IAO_0000111 "activity (of a radionuclide)" ;
+                 obo:IAO_0000115 "A radiation quality inhering in a radioactive substance by virtue of its transformation (disintegration) rate." ;
+                 obo:IAO_0000412 obo:pato.owl ;
+                 rdfs:label "activity (of a radionuclide)" .
+
+
+###  http://purl.obolibrary.org/obo/PATO_0001741
+obo:PATO_0001741 rdf:type owl:Class ;
+                 rdfs:subClassOf obo:PATO_0001740 ;
+                 obo:IAO_0000111 "radioactive" ;
+                 obo:IAO_0000115 "A radiation quality inhering in bearer by virtue of the bearer's exhibiting or being caused by radioactivity." ;
+                 obo:IAO_0000412 obo:pato.owl ;
+                 rdfs:label "radioactive" .
+
+
+###  http://purl.obolibrary.org/obo/PATO_0001792
+obo:PATO_0001792 rdf:type owl:Class ;
+                 rdfs:subClassOf obo:PATO_0000140 ;
+                 obo:IAO_0000111 "left side of" ;
+                 obo:IAO_0000115 "A spatial quality inhering in a bearer by virtue of the bearer's being located on left side of from the a another entity." ;
+                 obo:IAO_0000412 obo:pato.owl ;
+                 rdfs:label "left side of" .
+
+
+###  http://purl.obolibrary.org/obo/PATO_0001793
+obo:PATO_0001793 rdf:type owl:Class ;
+                 rdfs:subClassOf obo:PATO_0000140 ;
+                 obo:IAO_0000111 "right side of" ;
+                 obo:IAO_0000115 "A spatial quality inhering in a bearer by virtue of the bearer's being located on right side of a another entity." ;
+                 obo:IAO_0000412 obo:pato.owl ;
+                 rdfs:label "right side of" .
+
+
+###  http://purl.obolibrary.org/obo/PATO_0001894
+obo:PATO_0001894 rdf:type owl:Class ;
+                 rdfs:subClassOf obo:PATO_0000047 ;
+                 obo:IAO_0000111 "phenotypic sex" ;
+                 obo:IAO_0000115 "An organismal quality inhering in a bearer by virtue of the bearer's physical expression of sexual characteristics." ;
+                 obo:IAO_0000412 obo:pato.owl ;
+                 rdfs:label "phenotypic sex" .
+
+
+##  http://purl.obolibrary.org/obo/PATO_0002201
+obo:PATO_0002201 rdf:type owl:Class ;
+                 rdfs:subClassOf obo:PATO_0000186 ;
+                 obo:IAO_0000111 "handedness" ;
+                 obo:IAO_0000115 "A behavioral quality inhering ina bearer by virtue of the bearer's unequal distribution of fine motor skill between its left and right hands or feet." ;
+                 obo:IAO_0000412 obo:pato.owl ;
+                 rdfs:label "handedness" .
+
+
+###  http://purl.obolibrary.org/obo/PATO_0002202
+obo:PATO_0002202 rdf:type owl:Class ;
+                 rdfs:subClassOf obo:PATO_0002201 ;
+                 obo:IAO_0000111 "left handedness" ;
+                 obo:IAO_0000115 "Handedness where the organism preferentially uses the left hand or foot for tasks requiring the use of a single hand or foot or a dominant hand or foot." ;
+                 obo:IAO_0000412 obo:pato.owl ;
+                 rdfs:label "left handedness" .
+
+
+###  http://purl.obolibrary.org/obo/PATO_0002203
+obo:PATO_0002203 rdf:type owl:Class ;
+                 rdfs:subClassOf obo:PATO_0002201 ;
+                 obo:IAO_0000111 "right handedness" ;
+                 obo:IAO_0000115 "Handedness where the organism preferentially uses the right hand or foot for tasks requiring the use of a single hand or foot or a dominant hand or foot." ;
+                 obo:IAO_0000412 obo:pato.owl ;
+                 rdfs:label "right handedness" .
+
+
+###  http://purl.obolibrary.org/obo/PATO_0002204
+obo:PATO_0002204 rdf:type owl:Class ;
+                 rdfs:subClassOf obo:PATO_0002201 ;
+                 obo:IAO_0000111 "ambidextrous handedness" ;
+                 obo:IAO_0000115 "Handedness where the organism exhibits no overall dominance in the use of right or left hand or foot in the performance of tasks that require one hand or foot or a dominant hand or foot." ;
+                 obo:IAO_0000412 obo:pato.owl ;
+                 rdfs:label "ambidextrous handedness" .
+
+
+###  http://purl.obolibrary.org/obo/PATO_0002243
+obo:PATO_0002243 rdf:type owl:Class ;
+                 rdfs:subClassOf obo:PATO_0001574 ;
+                 obo:IAO_0000111 "fluid flow rate" ;
+                 obo:IAO_0000115 "A physical quality inhering in a fluid (liquid or gas) by virtue of the amount of fluid which passes through a given surface per unit time." ;
+                 obo:IAO_0000412 obo:pato.owl ;
+                 rdfs:label "fluid flow rate" .
+
+
+##  http://purl.obolibrary.org/obo/UBERON_0000178
+obo:UBERON_0000178 rdf:type owl:Class ;
+                   rdfs:subClassOf obo:UBERON_0006314 ;
+                   obo:IAO_0000111 "blood" ;
+                   obo:IAO_0000115 "A fluid that is composed of blood plasma and erythrocytes." ;
+                   obo:IAO_0000412 obo:uberon.owl ;
+                   rdfs:label "blood" .
+
+
+##  http://purl.obolibrary.org/obo/UBERON_0000463
+obo:UBERON_0000463 rdf:type owl:Class ;
+                   rdfs:subClassOf obo:UBERON_0000465 ;
+                   obo:IAO_0000111 "organism substance" ;
+                   obo:IAO_0000115 "Material anatomical entity in a gaseous, liquid, semisolid or solid state; produced by anatomical structures or derived from inhaled and ingested substances that have been modified by anatomical structures as they pass through the body." ;
+                   obo:IAO_0000412 obo:uberon.owl ;
+                   rdfs:label "organism substance" .
+
+
+###  http://purl.obolibrary.org/obo/UBERON_0000465
+obo:UBERON_0000465 rdf:type owl:Class ;
+                   rdfs:subClassOf obo:BFO_0000040 ;
+                   obo:IAO_0000111 "material anatomical entity" ;
+                   obo:IAO_0000115 "Anatomical entity that has mass." ;
+                   obo:IAO_0000412 obo:uberon.owl ;
+
+
+##  http://purl.obolibrary.org/obo/UBERON_0000477
+obo:UBERON_0000477 rdf:type owl:Class ;
+                   rdfs:subClassOf obo:BFO_0000040 ;
+                   obo:IAO_0000111 "anatomical cluster" ;
+                   obo:IAO_0000115 "Anatomical group that has its parts adjacent to one another." ;
+                   obo:IAO_0000412 obo:uberon.owl ;
+                   rdfs:label "anatomical cluster" .
+
+
+###  http://purl.obolibrary.org/obo/UBERON_0000479
+obo:UBERON_0000479 rdf:type owl:Class ;
+                   rdfs:subClassOf obo:UBERON_0000465 ;
+                   obo:IAO_0000111 "tissue" ;
+                   obo:IAO_0000115 "Multicellular anatomical structure that consists of many cells of one or a few types, arranged in an extracellular matrix such that their long-range organisation is at least partly a repetition of their short-range organisation." ;
+                   obo:IAO_0000412 obo:uberon.owl ;
+                   rdfs:label "tissue" .
+
+
+###  http://purl.obolibrary.org/obo/UBERON_0000481
+obo:UBERON_0000481 rdf:type owl:Class ;
+                   rdfs:subClassOf obo:UBERON_0000465 ;
+                   obo:IAO_0000111 "multi-tissue structure" ;
+                   obo:IAO_0000115 "Anatomical structure that has as its parts two or more portions of tissue of at least two different types and which through specific morphogenetic processes forms a single distinct structural unit demarcated by bona-fide boundaries from other distinct structural units of different types." ;
+                   obo:IAO_0000412 obo:uberon.owl ;
+                   rdfs:label "multi-tissue structure" .
+
+
+##  http://purl.obolibrary.org/obo/UBERON_0000948
+obo:UBERON_0000948 rdf:type owl:Class ;
+                   rdfs:subClassOf obo:UBERON_0000465 ;
+                   obo:IAO_0000111 "heart" ;
+                   obo:IAO_0000115 "A myogenic muscular circulatory organ found in the vertebrate cardiovascular system composed of chambers of cardiac muscle. It is the primary circulatory organ." ;
+                   obo:IAO_0000412 obo:uberon.owl ;
+                   rdfs:label "heart" .
+
+
+
+##  http://purl.obolibrary.org/obo/UBERON_0000955
+obo:UBERON_0000955 rdf:type owl:Class ;
+                   rdfs:subClassOf obo:UBERON_0000465 ;
+                   obo:IAO_0000111 "brain" ;
+                   obo:IAO_0000115 "The brain is the center of the nervous system in all vertebrate, and most invertebrate, animals. Some primitive animals such as jellyfish and starfish have a decentralized nervous system without a brain, while sponges lack any nervous system at all. In vertebrates, the brain is located in the head, protected by the skull and close to the primary sensory apparatus of vision, hearing, balance, taste, and smell[WP]." ;
+                   obo:IAO_0000412 obo:uberon.owl ;
+                   rdfs:label "brain" .
+
+
+
+##  http://purl.obolibrary.org/obo/UBERON_0000956
+obo:UBERON_0000956 rdf:type owl:Class ;
+                   rdfs:subClassOf obo:UBERON_0000465 ;
+                   obo:IAO_0000111 "cerebral cortex" ;
+                   obo:IAO_0000115 "The thin layer of gray matter on the surface of the cerebral hemisphere that develops from the telencephalon. It consists of the neocortex (6 layered cortex or isocortex), the hippocampal formation and the olfactory cortex." ;
+                   obo:IAO_0000412 obo:uberon.owl ;
+                   rdfs:label "cerebral cortex" .
+
+
+##  http://purl.obolibrary.org/obo/UBERON_0001359
+obo:UBERON_0001359 rdf:type owl:Class ;
+                   rdfs:subClassOf obo:UBERON_0006314 ;
+                   obo:IAO_0000111 "cerebrospinal fluid" ;
+                   obo:IAO_0000115 "A clear, colorless, bodily fluid, that occupies the subarachnoid space and the ventricular system around and inside the brain and spinal cord." ;
+                   obo:IAO_0000412 obo:uberon.owl ;
+                   rdfs:label "cerebrospinal fluid" .
+
+
+
+##  http://purl.obolibrary.org/obo/UBERON_0001621
+obo:UBERON_0001621 rdf:type owl:Class ;
+                   rdfs:subClassOf obo:UBERON_0000465 ;
+                   obo:IAO_0000111 "coronary artery" ;
+                   obo:IAO_0000115 "An artery that supplies the myocardium." ;
+                   obo:IAO_0000412 obo:uberon.owl ;
+                   rdfs:label "coronary artery" .
+
+
+###  http://purl.obolibrary.org/obo/UBERON_0001638
+obo:UBERON_0001638 rdf:type owl:Class ;
+                   rdfs:subClassOf obo:UBERON_0000465 ;
+                   obo:IAO_0000111 "vein" ;
+                   obo:IAO_0000115 "Any of the tubular branching vessels that carry blood from the capillaries toward the heart." ;
+                   obo:IAO_0000412 obo:uberon.owl ;
+
+
+
+##  http://purl.obolibrary.org/obo/UBERON_0006314
+obo:UBERON_0006314 rdf:type owl:Class ;
+                   rdfs:subClassOf obo:UBERON_0000463 ;
+                   obo:IAO_0000111 "bodily fluid" ;
+                   obo:IAO_0000115 "Liquid components of living organisms. includes fluids that are excreted or secreted from the body as well as body water that normally is not." ;
+                   obo:IAO_0000412 obo:uberon.owl ;
+                   rdfs:label "bodily fluid" .
+
+
+##  http://purl.obolibrary.org/obo/UBERON_0013755
+obo:UBERON_0013755 rdf:type owl:Class ;
+                   rdfs:subClassOf obo:UBERON_0000178 ;
+                   obo:IAO_0000111 "arterial blood" ;
+                   obo:IAO_0000115 "A blood that is part of a artery." ;
+                   obo:IAO_0000412 obo:uberon.owl ;
+                   rdfs:label "arterial blood" .
+
+
+###  http://purl.obolibrary.org/obo/UBERON_0013756
+obo:UBERON_0013756 rdf:type owl:Class ;
+                   rdfs:subClassOf obo:UBERON_0000178 ;
+                   obo:IAO_0000111 "venous blood" ;
+                   obo:IAO_0000115 "A blood that is part of a vein." ;
+                   obo:IAO_0000412 obo:uberon.owl ;
+                   rdfs:label "venous blood" .
+
+
+##  http://purl.obolibrary.org/obo/UO_0000001
+obo:UO_0000001 rdf:type owl:Class ;
+               rdfs:subClassOf obo:IAO_0000003 ;
+               obo:IAO_0000111 "length unit" ;
+               obo:IAO_0000115 "A unit which is a standard measure of the distance between two points." ;
+               obo:IAO_0000412 obo:uo.owl ;
+               rdfs:label "length unit" .
+
+
+###  http://purl.obolibrary.org/obo/UO_0000002
+obo:UO_0000002 rdf:type owl:Class ;
+               rdfs:subClassOf obo:IAO_0000003 ;
+               obo:IAO_0000111 "mass unit" ;
+               obo:IAO_0000115 "A unit which is a standard measure of the amount of matter/energy of a physical object." ;
+               obo:IAO_0000412 obo:uo.owl ;
+               rdfs:label "mass unit" .
+
+
+###  http://purl.obolibrary.org/obo/UO_0000003
+obo:UO_0000003 rdf:type owl:Class ;
+               rdfs:subClassOf obo:IAO_0000003 ;
+               obo:IAO_0000111 "time unit" ;
+               obo:IAO_0000115 "A unit which is a standard measure of the dimension in which events occur in sequence." ;
+               obo:IAO_0000412 obo:uo.owl ;
+               rdfs:label "time unit" .
+
+
+###  http://purl.obolibrary.org/obo/UO_0000005
+obo:UO_0000005 rdf:type owl:Class ;
+               rdfs:subClassOf obo:IAO_0000003 ;
+               obo:IAO_0000111 "temperature unit" ;
+               obo:IAO_0000412 obo:uo.owl ;
+               rdfs:label "temperature unit" .
+
+
+###  http://purl.obolibrary.org/obo/UO_0000006
+obo:UO_0000006 rdf:type owl:Class ;
+               rdfs:subClassOf obo:IAO_0000003 ;
+               obo:IAO_0000111 "substance unit" ;
+               obo:IAO_0000412 obo:uo.owl ;
+               rdfs:label "substance unit" .
+
+
+###  http://purl.obolibrary.org/obo/UO_0000051
+obo:UO_0000051 rdf:type owl:Class ;
+               rdfs:subClassOf obo:IAO_0000003 ;
+               obo:IAO_0000111 "concentration unit" ;
+               obo:IAO_0000412 obo:uo.owl ;
+               rdfs:label "concentration unit" .
+
+
+###  http://purl.obolibrary.org/obo/UO_0000095
+obo:UO_0000095 rdf:type owl:Class ;
+               rdfs:subClassOf obo:IAO_0000003 ;
+               obo:IAO_0000111 "volume unit" ;
+               obo:IAO_0000412 obo:uo.owl ;
+               rdfs:label "volume unit" .
+
+
+###  http://purl.obolibrary.org/obo/UO_0000105
+obo:UO_0000105 rdf:type owl:Class ;
+               rdfs:subClassOf obo:IAO_0000003 ;
+               obo:IAO_0000111 "frequency unit" ;
+               obo:IAO_0000412 obo:uo.owl ;
+               rdfs:label "frequency unit" .
+
+
+###  http://purl.obolibrary.org/obo/UO_0000109
+obo:UO_0000109 rdf:type owl:Class ;
+               rdfs:subClassOf obo:IAO_0000003 ;
+               obo:IAO_0000111 "pressure unit" ;
+               obo:IAO_0000412 obo:uo.owl ;
+               rdfs:label "pressure unit" .
+
+
+###  http://purl.obolibrary.org/obo/UO_0000270
+obo:UO_0000270 rdf:type owl:Class ;
+               rdfs:subClassOf obo:IAO_0000003 ;
+               obo:IAO_0000111 "volumetric flow rate unit" ;
+               obo:IAO_0000412 obo:uo.owl ;
+               rdfs:label "volumetric flow rate unit" .
+
+
+###  http://purl.obolibrary.org/obo/UO_0000280
+obo:UO_0000280 rdf:type owl:Class ;
+               rdfs:subClassOf obo:IAO_0000003 ;
+               obo:IAO_0000111 "rate unit" ;
+               obo:IAO_0000412 obo:uo.owl ;
+               rdfs:label "rate unit" .
+
+
+##  http://www.w3.org/2002/07/owl#Thing
+owl:Thing rdf:type owl:Class .
+
+
 
 
 ###  http://purl.org/nidash/nidm#AcquisitionMethod
@@ -4252,5 +11457,565 @@ nidm:k-spaceTraversalScheme rdf:type owl:Class ;
               rdfs:subClassOf nidm:AcquisitionObjectQuality ;
               obo:IAO_0000115 "The k-space traversal scheme is an acquisition object quality that describes, in a magnetic resonance imaging acquisition, the path in k-space along which the signal is acquired."^^xsd:string ;
               obo:IAO_0000114 obo:IAO_0000428 .
+
+
+#################################################################
+#    Individuals
+#################################################################
+
+###  http://purl.obolibrary.org/obo/IAO_0000120
+obo:IAO_0000120 rdf:type owl:NamedIndividual ,
+                         obo:IAO_0000078 ,
+                         owl:Thing ;
+                obo:IAO_0000111 "metadata complete"@en ;
+                obo:IAO_0000115 "Class has all its metadata, but is either not guaranteed to be in its final location in the asserted IS_A hierarchy or refers to another class that is not complete."@en ;
+                rdfs:label "metadata complete"@en .
+
+
+###  http://purl.obolibrary.org/obo/IAO_0000122
+obo:IAO_0000122 rdf:type owl:NamedIndividual ,
+                         obo:IAO_0000078 ,
+                         owl:Thing ;
+                obo:IAO_0000111 "ready for release"@en ;
+                obo:IAO_0000115 "Class has undergone final review, is ready for use, and will be included in the next release. Any class lacking \"ready_for_release\" should be considered likely to change place in hierarchy, have its definition refined, or be obsoleted in the next release.  Those classes deemed \"ready_for_release\" will also derived from a chain of ancestor classes that are also \"ready_for_release.\""@en ;
+                rdfs:label "ready for release"@en .
+
+
+###  http://purl.obolibrary.org/obo/IAO_0000123
+obo:IAO_0000123 rdf:type owl:NamedIndividual ,
+                         obo:IAO_0000078 ,
+                         owl:Thing ;
+                obo:IAO_0000111 "metadata incomplete"@en ;
+                obo:IAO_0000115 "Class is being worked on; however, the metadata (including definition) are not complete or sufficiently clear to the branch editors."@en ;
+                rdfs:label "metadata incomplete"@en .
+
+
+###  http://purl.obolibrary.org/obo/IAO_0000124
+obo:IAO_0000124 rdf:type owl:NamedIndividual ,
+                         obo:IAO_0000078 ,
+                         owl:Thing ;
+                obo:IAO_0000111 "uncurated"@en ;
+                obo:IAO_0000115 "Nothing done yet beyond assigning a unique class ID and proposing a preferred term."@en ;
+                rdfs:label "uncurated"@en .
+
+
+###  http://purl.obolibrary.org/obo/IAO_0000125
+obo:IAO_0000125 rdf:type owl:NamedIndividual ,
+                         obo:IAO_0000078 ,
+                         owl:Thing ;
+                obo:IAO_0000111 "pending final vetting"@en ;
+                obo:IAO_0000115 "All definitions, placement in the asserted IS_A hierarchy and required minimal metadata are complete. The class is awaiting a final review by someone other than the term editor."@en ;
+                rdfs:label "pending final vetting"@en .
+
+
+###  http://purl.obolibrary.org/obo/IAO_0000228
+obo:IAO_0000228 rdf:type owl:NamedIndividual ,
+                         obo:IAO_0000225 ;
+                obo:IAO_0000111 "term imported"@en ;
+                obo:IAO_0000116 "This is to be used when the original term has been replaced by a term imported from an other ontology. An editor note should indicate what is the URI of the new term to use."@en ;
+                rdfs:label "term imported"@en .
+
+
+###  http://purl.obolibrary.org/obo/IAO_0000423
+obo:IAO_0000423 rdf:type owl:NamedIndividual ,
+                         obo:IAO_0000078 ;
+                obo:IAO_0000111 "to be replaced with external ontology term"@en ;
+                obo:IAO_0000115 "Terms with this status should eventually replaced with a term from another ontology."@en ;
+                obo:IAO_0000117 "Alan Ruttenberg"@en ;
+                obo:IAO_0000119 "group:OBI"@en ;
+                rdfs:label "to be replaced with external ontology term"@en .
+
+
+###  http://purl.obolibrary.org/obo/IAO_0000428
+obo:IAO_0000428 rdf:type owl:NamedIndividual ,
+                         obo:IAO_0000078 ;
+                obo:IAO_0000111 "requires discussion"@en ;
+                obo:IAO_0000115 "A term that is metadata complete, has been reviewed, and problems have been identified that require discussion before release. Such a term requires editor note(s) to identify the outstanding issues."@en ;
+                obo:IAO_0000117 "Alan Ruttenberg"@en ;
+                obo:IAO_0000119 "group:OBI"@en ;
+                rdfs:label "requires discussion"@en .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0000325
+obo:OBI_0000325 rdf:type owl:NamedIndividual ,
+                         obo:IAO_0000098 ;
+                obo:IAO_0000111 "zip"@en ;
+                obo:IAO_0000112 "MagicDraw MDZIP archive, Java JAR file."@en ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "zip is a format standard of a digital entity that is conformant with the PKWARE .ZIP file format specification  (http://www.pkware.com/index.php?option=com_content&task=view&id=59&Itemid=103/)"@en ;
+                obo:IAO_0000117 "person:Jennifer Fostel"@en ;
+                obo:IAO_0000119 "web-page:http://www.pkware.com/index.php?option=com_content&task=view&id=59&Itemid=103/" ;
+                rdfs:label "zip"@en .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0000326
+obo:OBI_0000326 rdf:type owl:NamedIndividual ,
+                         obo:IAO_0000098 ;
+                obo:IAO_0000111 "tar"@en ;
+                obo:IAO_0000112 "Example.tar file."@en ;
+                obo:IAO_0000114 obo:IAO_0000125 ;
+                obo:IAO_0000115 "tar is a format standard of a digital entity that is conformant with the tape archive file format as standardized by POSIX.1-1998, POSIX.1-2001, or any other tar format compliant with the GNU tar specification. (http://www.gnu.org/software/tar/manual/)"@en ;
+                obo:IAO_0000117 "person:Jennifer Fostel"@en ;
+                obo:IAO_0000119 "web-page:http://www.gnu.org/software/tar/manual/" ;
+                rdfs:label "tar"@en .
+
+
+###  http://purl.obolibrary.org/obo/OBI_0000770
+obo:OBI_0000770 rdf:type owl:NamedIndividual ,
+                         obo:OBI_0000835 ;
+                obo:IAO_0000111 "Bruker Corporation" ;
+                obo:IAO_0000114 obo:IAO_0000123 ;
+                obo:IAO_0000117 "Philippe Rocca-Serra" ;
+                rdfs:label "Bruker Corporation" .
+
+
+###  http://purl.obolibrary.org/obo/UO_0000008
+obo:UO_0000008 rdf:type owl:NamedIndividual ,
+                        obo:UO_0000001 ;
+               obo:IAO_0000111 "meter" ;
+               obo:IAO_0000115 "A length unit which is equal to the length of the path traveled by light in vacuum during a time interval of 1/299 792 458 of a second." ;
+               obo:IAO_0000118 "m" ;
+               obo:IAO_0000412 obo:uo.owl ;
+               rdfs:label "meter" .
+
+
+###  http://purl.obolibrary.org/obo/UO_0000009
+obo:UO_0000009 rdf:type owl:NamedIndividual ,
+                        obo:UO_0000002 ;
+               obo:IAO_0000111 "kilogram" ;
+               obo:IAO_0000115 "A mass unit which is equal to the mass of the International Prototype Kilogram kept by the BIPM at Svres, France." ;
+               obo:IAO_0000118 "kg" ;
+               obo:IAO_0000412 obo:uo.owl ;
+               rdfs:label "kilogram" .
+
+
+###  http://purl.obolibrary.org/obo/UO_0000010
+obo:UO_0000010 rdf:type owl:NamedIndividual ,
+                        obo:UO_0000003 ;
+               obo:IAO_0000111 "second" ;
+               obo:IAO_0000115 "A time unit which is equal to the duration of 9 192 631 770 periods of the radiation corresponding to the transition between the two hyperfine levels of the ground state of the caesium 133 atom." ;
+               obo:IAO_0000118 "s" ,
+                               "sec" ;
+               obo:IAO_0000412 obo:uo.owl ;
+               rdfs:label "second" .
+
+
+###  http://purl.obolibrary.org/obo/UO_0000015
+obo:UO_0000015 rdf:type owl:NamedIndividual ,
+                        obo:UO_0000001 ;
+               obo:IAO_0000111 "centimeter" ;
+               obo:IAO_0000115 "A length unit which is equal to one hundredth of a meter or 10^[-2] m." ;
+               obo:IAO_0000118 "cm" ;
+               obo:IAO_0000412 obo:uo.owl ;
+               rdfs:label "centimeter" .
+
+
+###  http://purl.obolibrary.org/obo/UO_0000016
+obo:UO_0000016 rdf:type owl:NamedIndividual ,
+                        obo:UO_0000001 ;
+               obo:IAO_0000111 "millimeter" ;
+               obo:IAO_0000115 "A length unit which is equal to one thousandth of a meter or 10^[-3] m." ;
+               obo:IAO_0000118 "mm" ;
+               obo:IAO_0000412 obo:uo.owl ;
+               rdfs:label "millimeter" .
+
+
+###  http://purl.obolibrary.org/obo/UO_0000017
+obo:UO_0000017 rdf:type owl:NamedIndividual ,
+                        obo:UO_0000001 ;
+               obo:IAO_0000111 "micrometer" ;
+               obo:IAO_0000115 "A length unit which is equal to one millionth of a meter or 10^[-6] m." ;
+               obo:IAO_0000118 "um" ;
+               obo:IAO_0000412 obo:uo.owl ;
+               rdfs:label "micrometer" .
+
+
+###  http://purl.obolibrary.org/obo/UO_0000018
+obo:UO_0000018 rdf:type owl:NamedIndividual ,
+                        obo:UO_0000001 ;
+               obo:IAO_0000111 "nanometer" ;
+               obo:IAO_0000115 "A length unit which is equal to one thousandth of one millionth of a meter or 10^[-9] m." ;
+               obo:IAO_0000118 "nm" ;
+               obo:IAO_0000412 obo:uo.owl ;
+               rdfs:label "nanometer" .
+
+
+###  http://purl.obolibrary.org/obo/UO_0000019
+obo:UO_0000019 rdf:type owl:NamedIndividual ,
+                        obo:UO_0000001 ;
+               obo:IAO_0000111 "angstrom" ;
+               obo:IAO_0000115 "A length unit which is equal to 10 [-10] m." ;
+               obo:IAO_0000412 obo:uo.owl ;
+               rdfs:label "angstrom" .
+
+
+###  http://purl.obolibrary.org/obo/UO_0000021
+obo:UO_0000021 rdf:type owl:NamedIndividual ,
+                        obo:UO_0000002 ;
+               obo:IAO_0000111 "gram" ;
+               obo:IAO_0000115 "A mass unit which is equal to one thousandth of a kilogram or 10^[-3] kg." ;
+               obo:IAO_0000118 "g" ;
+               obo:IAO_0000412 obo:uo.owl ;
+               rdfs:label "gram" .
+
+
+###  http://purl.obolibrary.org/obo/UO_0000022
+obo:UO_0000022 rdf:type owl:NamedIndividual ,
+                        obo:UO_0000002 ;
+               obo:IAO_0000111 "milligram" ;
+               obo:IAO_0000115 "A mass unit which is equal to one thousandth of a gram or 10^[-3] g." ;
+               obo:IAO_0000118 "mg" ;
+               obo:IAO_0000412 obo:uo.owl ;
+               rdfs:label "milligram" .
+
+
+###  http://purl.obolibrary.org/obo/UO_0000023
+obo:UO_0000023 rdf:type owl:NamedIndividual ,
+                        obo:UO_0000002 ;
+               obo:IAO_0000111 "microgram" ;
+               obo:IAO_0000115 "A mass unit which is equal to one millionth of a gram or 10^[-6] g." ;
+               obo:IAO_0000118 "ug" ;
+               obo:IAO_0000412 obo:uo.owl ;
+               rdfs:label "microgram" .
+
+
+###  http://purl.obolibrary.org/obo/UO_0000024
+obo:UO_0000024 rdf:type owl:NamedIndividual ,
+                        obo:UO_0000002 ;
+               obo:IAO_0000111 "nanogram" ;
+               obo:IAO_0000115 "A mass unit which is equal to one thousandth of one millionth of a gram or 10^[-9] g." ;
+               obo:IAO_0000118 "ng" ;
+               obo:IAO_0000412 obo:uo.owl ;
+               rdfs:label "nanogram" .
+
+
+###  http://purl.obolibrary.org/obo/UO_0000025
+obo:UO_0000025 rdf:type owl:NamedIndividual ,
+                        obo:UO_0000002 ;
+               obo:IAO_0000111 "picogram" ;
+               obo:IAO_0000115 "A mass unit which is equal to 10^[-12] g." ;
+               obo:IAO_0000118 "pg" ;
+               obo:IAO_0000412 obo:uo.owl ;
+               rdfs:label "picogram" .
+
+
+###  http://purl.obolibrary.org/obo/UO_0000027
+obo:UO_0000027 rdf:type owl:NamedIndividual ,
+                        obo:UO_0000005 ;
+               obo:IAO_0000111 "degree Celsius" ;
+               obo:IAO_0000115 "A temperature unit which is equal to one kelvin degree. However, they have their zeros at different points. The centigrade scale has its zero at 273.15 K." ;
+               obo:IAO_0000118 "C" ,
+                               "degree C" ;
+               obo:IAO_0000412 obo:uo.owl ;
+               rdfs:label "degree Celsius" .
+
+
+###  http://purl.obolibrary.org/obo/UO_0000031
+obo:UO_0000031 rdf:type owl:NamedIndividual ,
+                        obo:UO_0000003 ;
+               obo:IAO_0000111 "minute" ;
+               obo:IAO_0000115 "A time unit which is equal to 60 seconds." ;
+               obo:IAO_0000118 "min" ;
+               obo:IAO_0000412 obo:uo.owl ;
+               rdfs:label "minute" .
+
+
+###  http://purl.obolibrary.org/obo/UO_0000032
+obo:UO_0000032 rdf:type owl:NamedIndividual ,
+                        obo:UO_0000003 ;
+               obo:IAO_0000111 "hour" ;
+               obo:IAO_0000115 "A time unit which is equal to 3600 seconds or 60 minutes." ;
+               obo:IAO_0000118 "h" ,
+                               "hr" ;
+               obo:IAO_0000412 obo:uo.owl ;
+               rdfs:label "hour" .
+
+
+###  http://purl.obolibrary.org/obo/UO_0000033
+obo:UO_0000033 rdf:type owl:NamedIndividual ,
+                        obo:UO_0000003 ;
+               obo:IAO_0000111 "day" ;
+               obo:IAO_0000115 "A time unit which is equal to 24 hours." ;
+               obo:IAO_0000412 obo:uo.owl ;
+               rdfs:label "day" .
+
+
+###  http://purl.obolibrary.org/obo/UO_0000034
+obo:UO_0000034 rdf:type owl:NamedIndividual ,
+                        obo:UO_0000003 ;
+               obo:IAO_0000111 "week" ;
+               obo:IAO_0000115 "A time unit which is equal to 7 days." ;
+               obo:IAO_0000412 obo:uo.owl ;
+               rdfs:label "week" .
+
+
+###  http://purl.obolibrary.org/obo/UO_0000035
+obo:UO_0000035 rdf:type owl:NamedIndividual ,
+                        obo:UO_0000003 ;
+               obo:IAO_0000111 "month" ;
+               obo:IAO_0000115 "A time unit which is approximately equal to the length of time of one of cycle of the moon's phases which in science is taken to be equal to 30 days." ;
+               obo:IAO_0000412 obo:uo.owl ;
+               rdfs:label "month" .
+
+
+###  http://purl.obolibrary.org/obo/UO_0000036
+obo:UO_0000036 rdf:type owl:NamedIndividual ,
+                        obo:UO_0000003 ;
+               obo:IAO_0000111 "year" ;
+               obo:IAO_0000115 "A time unit which is equal to 12 months which is science is taken to be equal to 365.25 days." ;
+               obo:IAO_0000412 obo:uo.owl ;
+               rdfs:label "year" .
+
+
+###  http://purl.obolibrary.org/obo/UO_0000039
+obo:UO_0000039 rdf:type owl:NamedIndividual ,
+                        obo:UO_0000006 ;
+               obo:IAO_0000111 "micromole" ;
+               obo:IAO_0000115 "A substance unit equal to a millionth of a mol or 10^[-6] mol." ;
+               obo:IAO_0000118 "umol" ;
+               obo:IAO_0000412 obo:uo.owl ;
+               rdfs:label "micromole" .
+
+
+###  http://purl.obolibrary.org/obo/UO_0000041
+obo:UO_0000041 rdf:type owl:NamedIndividual ,
+                        obo:UO_0000006 ;
+               obo:IAO_0000111 "nanomole" ;
+               obo:IAO_0000115 "A substance unit equal to one thousandth of one millionth of a mole or 10^[-9] mol." ;
+               obo:IAO_0000118 "nmol" ;
+               obo:IAO_0000412 obo:uo.owl ;
+               rdfs:label "nanomole" .
+
+
+###  http://purl.obolibrary.org/obo/UO_0000042
+obo:UO_0000042 rdf:type owl:NamedIndividual ,
+                        obo:UO_0000006 ;
+               obo:IAO_0000111 "picomole" ;
+               obo:IAO_0000115 "A substance unit equal to 10^[-12] mol." ;
+               obo:IAO_0000118 "pmol" ;
+               obo:IAO_0000412 obo:uo.owl ;
+               rdfs:label "picomole" .
+
+
+###  http://purl.obolibrary.org/obo/UO_0000062
+obo:UO_0000062 rdf:type owl:NamedIndividual ,
+                        obo:UO_0000051 ;
+               obo:IAO_0000111 "molar" ;
+               obo:IAO_0000115 "A unit of concentration which expresses a concentration of 1 mole of solute per liter of solution (mol/L)." ;
+               obo:IAO_0000118 "M" ;
+               obo:IAO_0000412 obo:uo.owl ;
+               rdfs:label "molar" .
+
+
+###  http://purl.obolibrary.org/obo/UO_0000063
+obo:UO_0000063 rdf:type owl:NamedIndividual ,
+                        obo:UO_0000051 ;
+               obo:IAO_0000111 "millimolar" ;
+               obo:IAO_0000115 "A unit of molarity which is equal to one thousandth of a molar or 10^[-3] M." ;
+               obo:IAO_0000118 "mM" ;
+               obo:IAO_0000412 obo:uo.owl ;
+               rdfs:label "millimolar" .
+
+
+###  http://purl.obolibrary.org/obo/UO_0000064
+obo:UO_0000064 rdf:type owl:NamedIndividual ,
+                        obo:UO_0000051 ;
+               obo:IAO_0000111 "micromolar" ;
+               obo:IAO_0000115 "A unit of molarity which is equal to one millionth of a molar or 10^[-6] M." ;
+               obo:IAO_0000118 "uM" ;
+               obo:IAO_0000412 obo:uo.owl ;
+               rdfs:label "micromolar" .
+
+
+###  http://purl.obolibrary.org/obo/UO_0000065
+obo:UO_0000065 rdf:type owl:NamedIndividual ,
+                        obo:UO_0000051 ;
+               obo:IAO_0000111 "nanomolar" ;
+               obo:IAO_0000115 "A unit of molarity which is equal to one thousandth of one millionth of a molar or 10^[-9] M." ;
+               obo:IAO_0000118 "nM" ;
+               obo:IAO_0000412 obo:uo.owl ;
+               rdfs:label "nanomolar" .
+
+
+###  http://purl.obolibrary.org/obo/UO_0000066
+obo:UO_0000066 rdf:type owl:NamedIndividual ,
+                        obo:UO_0000051 ;
+               obo:IAO_0000111 "picomolar" ;
+               obo:IAO_0000115 "A unit of molarity which is equal to 10^[-12] M." ;
+               obo:IAO_0000118 "pM" ;
+               obo:IAO_0000412 obo:uo.owl ;
+               rdfs:label "picomolar" .
+
+
+###  http://purl.obolibrary.org/obo/UO_0000097
+obo:UO_0000097 rdf:type owl:NamedIndividual ,
+                        obo:UO_0000095 ;
+               obo:IAO_0000111 "cubic centimeter" ;
+               obo:IAO_0000115 "A volume unit which is equal to one millionth of a cubic meter or 10^[-9] m^[3], or to 1 ml." ;
+               obo:IAO_0000118 "cc" ;
+               obo:IAO_0000412 obo:uo.owl ;
+               rdfs:label "cubic centimeter" .
+
+
+###  http://purl.obolibrary.org/obo/UO_0000098
+obo:UO_0000098 rdf:type owl:NamedIndividual ,
+                        obo:UO_0000095 ;
+               obo:IAO_0000111 "milliliter" ;
+               obo:IAO_0000115 "A volume unit which is equal to one thousandth of a liter or 10^[-3] L, or to 1 cubic centimeter." ;
+               obo:IAO_0000118 "ml" ;
+               obo:IAO_0000412 obo:uo.owl ;
+               rdfs:label "milliliter" .
+
+
+###  http://purl.obolibrary.org/obo/UO_0000099
+obo:UO_0000099 rdf:type owl:NamedIndividual ,
+                        obo:UO_0000095 ;
+               obo:IAO_0000111 "liter" ;
+               obo:IAO_0000115 "A volume unit which is equal to one thousandth of a cubic meter or 10^[-3] m^[3], or to 1 decimeter." ;
+               obo:IAO_0000118 "L" ;
+               obo:IAO_0000412 obo:uo.owl ;
+               rdfs:label "liter" .
+
+
+###  http://purl.obolibrary.org/obo/UO_0000100
+obo:UO_0000100 rdf:type owl:NamedIndividual ,
+                        obo:UO_0000095 ;
+               obo:IAO_0000111 "cubic decimeter" ;
+               obo:IAO_0000115 "A volume unit which is equal to one thousand of a cubic meter or 10^[-3] m^[3], or to 1 L." ;
+               obo:IAO_0000412 obo:uo.owl ;
+               rdfs:label "cubic decimeter" .
+
+
+###  http://purl.obolibrary.org/obo/UO_0000101
+obo:UO_0000101 rdf:type owl:NamedIndividual ,
+                        obo:UO_0000095 ;
+               obo:IAO_0000111 "microliter" ;
+               obo:IAO_0000115 "A volume unit which is equal to one millionth of a liter or 10^[-6] L." ;
+               obo:IAO_0000118 "ul" ;
+               obo:IAO_0000412 obo:uo.owl ;
+               rdfs:label "microliter" .
+
+
+###  http://purl.obolibrary.org/obo/UO_0000102
+obo:UO_0000102 rdf:type owl:NamedIndividual ,
+                        obo:UO_0000095 ;
+               obo:IAO_0000111 "nanoliter" ;
+               obo:IAO_0000115 "A volume unit which is equal to one thousandth of one millionth of a liter or 10^[-9] L." ;
+               obo:IAO_0000118 "nl" ;
+               obo:IAO_0000412 obo:uo.owl ;
+               rdfs:label "nanoliter" .
+
+
+###  http://purl.obolibrary.org/obo/UO_0000103
+obo:UO_0000103 rdf:type owl:NamedIndividual ,
+                        obo:UO_0000095 ;
+               obo:IAO_0000111 "picoliter" ;
+               obo:IAO_0000115 "A volume unit which is equal to 10^[-12] L." ;
+               obo:IAO_0000118 "pl" ;
+               obo:IAO_0000412 obo:uo.owl ;
+               rdfs:label "picoliter" .
+
+
+###  http://purl.obolibrary.org/obo/UO_0000106
+obo:UO_0000106 rdf:type owl:NamedIndividual ,
+                        obo:UO_0000105 ;
+               obo:IAO_0000111 "hertz" ;
+               obo:IAO_0000115 "A frequency unit which is equal to 1 complete cycle of a recurring phenomenon in 1 second." ;
+               obo:IAO_0000412 obo:uo.owl ;
+               rdfs:label "hertz" .
+
+
+###  http://purl.obolibrary.org/obo/UO_0000163
+obo:UO_0000163 rdf:type owl:NamedIndividual ,
+                        obo:UO_0000051 ;
+               obo:IAO_0000111 "mass percentage" ;
+               obo:IAO_0000115 "A dimensionless concentration unit which denotes the mass of a substance in a mixture as a percentage of the mass of the entire mixture." ;
+               obo:IAO_0000118 "% w/w" ,
+                               "percent weight pr weight" ;
+               obo:IAO_0000412 obo:uo.owl ;
+               rdfs:label "mass percentage" .
+
+
+###  http://purl.obolibrary.org/obo/UO_0000164
+obo:UO_0000164 rdf:type owl:NamedIndividual ,
+                        obo:UO_0000051 ;
+               obo:IAO_0000111 "mass volume percentage" ;
+               obo:IAO_0000115 "A dimensionless concentration unit which denotes the mass of the substance in a mixture as a percentage of the volume of the entire mixture." ;
+               obo:IAO_0000118 "% w/v" ,
+                               "percent vol per vol" ;
+               obo:IAO_0000412 obo:uo.owl ;
+               rdfs:label "mass volume percentage" .
+
+
+###  http://purl.obolibrary.org/obo/UO_0000165
+obo:UO_0000165 rdf:type owl:NamedIndividual ,
+                        obo:UO_0000051 ;
+               obo:IAO_0000111 "volume percentage" ;
+               obo:IAO_0000115 "A dimensionless concentration unit which denotes the volume of the solute in mL per 100 mL of the resulting solution." ;
+               obo:IAO_0000118 "% v/v" ,
+                               "percent vol per vol" ;
+               obo:IAO_0000412 obo:uo.owl ;
+               rdfs:label "volume percentage" .
+
+
+###  http://purl.obolibrary.org/obo/UO_0000175
+obo:UO_0000175 rdf:type owl:NamedIndividual ,
+                        obo:UO_0000051 ;
+               obo:IAO_0000111 "gram per liter" ;
+               obo:IAO_0000115 "A mass unit density which is equal to mass of an object in grams divided by the volume in liters." ;
+               obo:IAO_0000118 "g per L" ,
+                               "g/L" ;
+               obo:IAO_0000412 obo:uo.owl ;
+               rdfs:label "gram per liter" .
+
+
+###  http://purl.obolibrary.org/obo/UO_0000176
+obo:UO_0000176 rdf:type owl:NamedIndividual ,
+                        obo:UO_0000051 ;
+               obo:IAO_0000111 "milligram per milliliter" ;
+               obo:IAO_0000115 "A mass unit density which is equal to mass of an object in milligrams divided by the volume in milliliters." ;
+               obo:IAO_0000118 "mg per ml" ,
+                               "mg/ml" ;
+               obo:IAO_0000412 obo:uo.owl ;
+               rdfs:label "milligram per milliliter" .
+
+
+###  http://purl.obolibrary.org/obo/UO_0000195
+obo:UO_0000195 rdf:type owl:NamedIndividual ,
+                        obo:UO_0000005 ;
+               obo:IAO_0000111 "degree Fahrenheit" ;
+               obo:IAO_0000115 "A temperature unit which is equal to 5/9ths of a kelvin. Negative 40 degrees Fahrenheit is equal to negative 40 degrees Celsius." ;
+               obo:IAO_0000412 obo:uo.owl ;
+               rdfs:label "degree Fahrenheit" .
+
+
+###  http://purl.obolibrary.org/obo/UO_0000196
+obo:UO_0000196 rdf:type owl:NamedIndividual ,
+                        obo:UO_0000051 ;
+               obo:IAO_0000111 "pH" ;
+               obo:IAO_0000115 "A dimensionless concentration notation which denotes the acidity of a solution in terms of activity of hydrogen ions (H+)." ;
+               obo:IAO_0000412 obo:uo.owl ;
+               rdfs:label "pH" .
+
+
+###  http://purl.obolibrary.org/obo/UO_0000207
+obo:UO_0000207 rdf:type owl:NamedIndividual ,
+                        obo:UO_0000051 ;
+               obo:IAO_0000111 "milliliter per liter" ;
+               obo:IAO_0000115 "A volume per unit volume unit which is equal to one millionth of a liter of solute in one liter of solution." ;
+               obo:IAO_0000118 "ml per L" ,
+                               "ml/l" ;
+               obo:IAO_0000412 obo:uo.owl ;
+               rdfs:label "milliliter per liter" .
+
+
+###  http://purl.obolibrary.org/obo/UO_0000208
+obo:UO_0000208 rdf:type owl:NamedIndividual ,
+                        obo:UO_0000051 ;
+               obo:IAO_0000111 "gram per deciliter" ;
+               obo:IAO_0000115 "A mass density unit which is equal to mass of an object in grams divided by the volume in deciliters." ;
+               obo:IAO_0000118 "g/dl" ;
+               obo:IAO_0000412 obo:uo.owl ;
+               rdfs:label "gram per deciliter" .
 
 


### PR DESCRIPTION
This PR adds OBI terms as well as terms from other ontologies present in the obi.owl file. I have not checked that all parent terms or terms used in the entry for each term is present. That task will be covered with a future PR, for now just adding terms relevant to NIDM-E.